### PR TITLE
Introduce Directories

### DIFF
--- a/cmd/fuse-server/fs.go
+++ b/cmd/fuse-server/fs.go
@@ -3,6 +3,7 @@ package fuseserver
 import (
 	"context"
 	"os"
+	"path"
 	"sync"
 	"time"
 
@@ -21,11 +22,13 @@ type fuseServer struct {
 	cryptServerClient    cpb.CryptServiceClient
 	cryptConn            *grpc.ClientConn
 	mu                   sync.RWMutex
-
-	nodeCounter uint64 // HACK: This is not how we should be generating inode numbers.
 }
 
-func newFUSEServer(logger *log.Logger, metadataServerAddr, cryptServerAddr string) (fs.FS, error) {
+func newFUSEServer(
+	logger *log.Logger,
+	metadataServerAddr,
+	cryptServerAddr string,
+) (fs.FS, error) {
 	metadataConn, err := grpc.Dial(metadataServerAddr, grpc.WithInsecure())
 	if err != nil {
 		return nil, err
@@ -52,163 +55,285 @@ func (f *fuseServer) Root() (fs.Node, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 
-	dir := Dir{fuseServer: f}
+	dir := Dir{
+		fserver: f,
+		path:    "kura-root",
+		inode:   fs.GenerateDynamicInode(0, "kura-root"),
+	}
 	return &dir, nil
 }
 
-// Dir implements both Node and Handle for the root directory.
+// Dir implements both fs.Node and fs.Handle for the root directory.
 type Dir struct {
-	fuseServer *fuseServer
+	fserver *fuseServer
+	path    string
+	inode   uint64
 }
 
 func (d *Dir) Attr(ctx context.Context, a *fuse.Attr) error {
-	a.Inode = 1
-	a.Mode = os.ModeDir | 0555
+	d.fserver.mu.Lock()
+	defer d.fserver.mu.Unlock()
+
+	if d.path == "kura-root" {
+		a.Inode = d.inode
+		a.Mode = os.ModeDir | 0555
+		a.Size = 0
+		return nil
+	}
+
+	req := &mpb.GetMetadataRequest{Path: d.path}
+	res, err := d.fserver.metadataServerClient.GetMetadata(ctx, req)
+	if err != nil {
+		return err
+	}
+
+	a.Inode = d.inode
+	a.Mode = os.ModeDir | os.FileMode(res.Metadata.Permissions)
+	a.Size = uint64(res.Metadata.Size)
+	a.Mtime = time.Unix(res.Metadata.LastModified.Seconds, 0)
+	a.Crtime = time.Unix(res.Metadata.Created.Seconds, 0)
+	// TODO(irfansharif): Include AccessTime.
 	return nil
 }
 
 func (d *Dir) Lookup(ctx context.Context, name string) (fs.Node, error) {
-	d.fuseServer.mu.Lock()
-	defer d.fuseServer.mu.Unlock()
+	d.fserver.mu.Lock()
+	defer d.fserver.mu.Unlock()
 
-	req := &mpb.GetFileRequest{Key: name}
-	_, err := d.fuseServer.metadataServerClient.GetFile(ctx, req) // TODO: We're discarding the response.
+	req := &mpb.GetDirectoryEntriesRequest{Path: d.path}
+	res, err := d.fserver.metadataServerClient.GetDirectoryEntries(ctx, req)
 	if err != nil {
-		return nil, fuse.ENOENT
+		return nil, err
 	}
 
-	return &File{name: name, parentDir: d}, nil
+	fpath := path.Join(d.path, name)
+	for _, entry := range res.Entries {
+		if entry.Path != fpath {
+			continue
+		}
+		if entry.IsDirectory {
+			dir := Dir{
+				fserver: d.fserver,
+				path:    fpath,
+				inode:   fs.GenerateDynamicInode(d.inode, fpath),
+			}
+			return &dir, nil
+		} else {
+			file := File{
+				path:    fpath,
+				fserver: d.fserver,
+				inode:   fs.GenerateDynamicInode(d.inode, fpath),
+			}
+			return &file, nil
+		}
+	}
+
+	return nil, fuse.ENOENT
 }
 
-func (d *Dir) Create(ctx context.Context, req *fuse.CreateRequest, res *fuse.CreateResponse) (fs.Node, fs.Handle, error) {
-	d.fuseServer.mu.Lock()
-	defer d.fuseServer.mu.Unlock()
+func (d *Dir) Create(
+	ctx context.Context,
+	req *fuse.CreateRequest,
+	res *fuse.CreateResponse,
+) (fs.Node, fs.Handle, error) {
+	d.fserver.mu.Lock()
+	defer d.fserver.mu.Unlock()
 
 	ts := time.Now().Unix()
-	metadata := &mpb.FileMetadata{
-		Created:      &mpb.FileMetadata_UnixTimestamp{Seconds: ts},
-		LastModified: &mpb.FileMetadata_UnixTimestamp{Seconds: ts},
-		Permissions:  0644,
+	metadata := &mpb.Metadata{
+		Created:      &mpb.Metadata_UnixTimestamp{Seconds: ts},
+		LastModified: &mpb.Metadata_UnixTimestamp{Seconds: ts},
+		Permissions:  uint32(req.Mode),
 		Size:         int64(0),
+		IsDirectory:  false,
 	}
 
-	rq := &mpb.PutFileRequest{Key: req.Name, File: []byte{}, Metadata: metadata}
-	_, err := d.fuseServer.metadataServerClient.PutFile(ctx, rq)
+	rq := &mpb.PutFileRequest{
+		Path:     path.Join(d.path, req.Name),
+		File:     []byte{},
+		Metadata: metadata,
+	}
+	_, err := d.fserver.metadataServerClient.PutFile(ctx, rq)
 	if err != nil {
-		return nil, nil, err // TODO(irfansharif): Propagate appropriate FUSE error.
+		return nil, nil, err
 	}
 
-	d.fuseServer.nodeCounter += 1
-	res.Node = fuse.NodeID(d.fuseServer.nodeCounter)
-	res.OpenResponse.Handle = fuse.HandleID(d.fuseServer.nodeCounter)
-	file := &File{name: req.Name, parentDir: d}
-	return file, file, nil
+	file := File{
+		path:    path.Join(d.path, req.Name),
+		fserver: d.fserver,
+		inode:   fs.GenerateDynamicInode(d.inode, path.Join(d.path, req.Name)),
+	}
+	res.Node = fuse.NodeID(file.inode)
+	res.OpenResponse.Handle = fuse.HandleID(file.inode)
+	return &file, &file, nil
+}
+
+func (d *Dir) Mkdir(
+	ctx context.Context,
+	req *fuse.MkdirRequest,
+) (fs.Node, error) {
+	d.fserver.mu.Lock()
+	defer d.fserver.mu.Unlock()
+
+	ts := time.Now().Unix()
+	metadata := &mpb.Metadata{
+		Created:      &mpb.Metadata_UnixTimestamp{Seconds: ts},
+		LastModified: &mpb.Metadata_UnixTimestamp{Seconds: ts},
+		Permissions:  uint32(req.Mode),
+		Size:         int64(0),
+		IsDirectory:  true,
+	}
+	rq := &mpb.CreateDirectoryRequest{
+		Path:     path.Join(d.path, req.Name),
+		Metadata: metadata,
+	}
+	_, err := d.fserver.metadataServerClient.CreateDirectory(ctx, rq)
+	if err != nil {
+		return nil, err
+	}
+
+	dir := Dir{
+		fserver: d.fserver,
+		path:    path.Join(d.path, req.Name),
+		inode:   fs.GenerateDynamicInode(d.inode, path.Join(d.path, req.Name)),
+	}
+	return &dir, nil
 }
 
 func (d *Dir) ReadDirAll(ctx context.Context) ([]fuse.Dirent, error) {
-	d.fuseServer.mu.Lock()
-	defer d.fuseServer.mu.Unlock()
+	d.fserver.mu.Lock()
+	defer d.fserver.mu.Unlock()
 
-	req := &mpb.GetDirectoryKeysRequest{}
-	res, err := d.fuseServer.metadataServerClient.GetDirectoryKeys(ctx, req)
+	req := &mpb.GetDirectoryEntriesRequest{Path: d.path}
+	res, err := d.fserver.metadataServerClient.GetDirectoryEntries(ctx, req)
 	if err != nil {
 		return nil, err
 	}
 
 	dirents := make([]fuse.Dirent, 0)
-	for i, key := range res.Keys {
-		// TODO: Ensure unique inode numbers.
+	for _, entry := range res.Entries {
+		var etype fuse.DirentType
+		if entry.IsDirectory {
+			etype = fuse.DT_Dir
+		} else {
+			etype = fuse.DT_File
+		}
+
 		dirents = append(dirents,
-			fuse.Dirent{Inode: uint64(i + 42), Name: key, Type: fuse.DT_File})
+			fuse.Dirent{
+				Inode: fs.GenerateDynamicInode(d.inode, entry.Path),
+				Name:  entry.Path[len(d.path+"/"):],
+				Type:  etype,
+			})
 	}
 
 	return dirents, nil
 }
 
-// File implements both Node and Handle for the hello file.
-type File struct {
-	name      string
-	parentDir *Dir
-}
+func (d *Dir) Remove(ctx context.Context, req *fuse.RemoveRequest) error {
+	d.fserver.mu.Lock()
+	defer d.fserver.mu.Unlock()
 
-func (f *File) Attr(ctx context.Context, a *fuse.Attr) error {
-	f.parentDir.fuseServer.mu.Lock()
-	defer f.parentDir.fuseServer.mu.Unlock()
-
-	req := &mpb.GetMetadataRequest{Key: f.name}
-	res, err := f.parentDir.fuseServer.metadataServerClient.GetMetadata(ctx, req)
-	if err != nil {
-		return err // TODO(irfansharif): Propagate appropriate FUSE error.
+	if req.Dir {
+		rq := &mpb.DeleteDirectoryRequest{Path: path.Join(d.path, req.Name)}
+		_, err := d.fserver.metadataServerClient.DeleteDirectory(ctx, rq)
+		if err != nil {
+			return err
+		}
+	} else {
+		rq := &mpb.DeleteFileRequest{Path: path.Join(d.path, req.Name)}
+		_, err := d.fserver.metadataServerClient.DeleteFile(ctx, rq)
+		if err != nil {
+			return err
+		}
 	}
-
-	a.Inode = 2   // TODO: Store this in metadata server.
-	a.Mode = 0444 // TODO: Extract this from req.Metadata.Permissions.
-	a.Size = uint64(res.Metadata.Size)
 
 	return nil
 }
 
-func (f *File) ReadAll(ctx context.Context) ([]byte, error) {
-	f.parentDir.fuseServer.mu.Lock()
-	defer f.parentDir.fuseServer.mu.Unlock()
+// File implements both fs.Node and fs.Handle.
+type File struct {
+	path    string
+	fserver *fuseServer
+	inode   uint64
+}
 
-	req := &mpb.GetFileRequest{Key: f.name}
-	res, err := f.parentDir.fuseServer.metadataServerClient.GetFile(ctx, req)
+func (f *File) Attr(ctx context.Context, a *fuse.Attr) error {
+	f.fserver.mu.Lock()
+	defer f.fserver.mu.Unlock()
+
+	return f.AttrLocked(ctx, a)
+}
+
+func (f *File) AttrLocked(ctx context.Context, a *fuse.Attr) error {
+	req := &mpb.GetMetadataRequest{Path: f.path}
+	res, err := f.fserver.metadataServerClient.GetMetadata(ctx, req)
 	if err != nil {
-		return nil, err // TODO(irfansharif): Propagate appropriate FUSE error.
+		return err
+	}
+
+	a.Inode = f.inode
+	a.Mode = os.FileMode(res.Metadata.Permissions)
+	a.Size = uint64(res.Metadata.Size)
+	a.Mtime = time.Unix(res.Metadata.LastModified.Seconds, 0)
+	a.Crtime = time.Unix(res.Metadata.Created.Seconds, 0)
+	return nil
+}
+
+func (f *File) ReadAll(ctx context.Context) ([]byte, error) {
+	f.fserver.mu.Lock()
+	defer f.fserver.mu.Unlock()
+
+	req := &mpb.GetFileRequest{Path: f.path}
+	res, err := f.fserver.metadataServerClient.GetFile(ctx, req)
+	if err != nil {
+		return nil, err
 	}
 
 	creq := &cpb.DecryptionRequest{Ciphertext: res.File}
-	cres, err := f.parentDir.fuseServer.cryptServerClient.Decrypt(ctx, creq)
+	cres, err := f.fserver.cryptServerClient.Decrypt(ctx, creq)
 	if err != nil {
-		f.parentDir.fuseServer.logger.Error(err.Error())
-		return nil, err // TODO(irfansharif): Propagate appropriate FUSE error.
+		return nil, err
 	}
 
 	return cres.Plaintext, nil
 }
 
-func (f *File) Write(ctx context.Context, req *fuse.WriteRequest, resp *fuse.WriteResponse) error {
-	f.parentDir.fuseServer.mu.Lock()
-	defer f.parentDir.fuseServer.mu.Unlock()
+func (f *File) Write(
+	ctx context.Context,
+	req *fuse.WriteRequest,
+	resp *fuse.WriteResponse,
+) error {
+	f.fserver.mu.Lock()
+	defer f.fserver.mu.Unlock()
 
 	creq := &cpb.EncryptionRequest{Plaintext: req.Data}
-	cres, err := f.parentDir.fuseServer.cryptServerClient.Encrypt(ctx, creq)
+	cres, err := f.fserver.cryptServerClient.Encrypt(ctx, creq)
 	if err != nil {
-		f.parentDir.fuseServer.logger.Error(err.Error())
-		return err // TODO(irfansharif): Propagate appropriate FUSE error.
+		return err
 	}
 
-	ts := time.Now().Unix()
-	metadata := &mpb.FileMetadata{
+	var attr fuse.Attr
+	f.AttrLocked(ctx, &attr)
+
+	metadata := &mpb.Metadata{
 		Size:         int64(len(req.Data)),
-		LastModified: &mpb.FileMetadata_UnixTimestamp{Seconds: ts},
+		LastModified: &mpb.Metadata_UnixTimestamp{Seconds: time.Now().Unix()},
+		Created:      &mpb.Metadata_UnixTimestamp{Seconds: attr.Crtime.Unix()},
+		Permissions:  uint32(attr.Mode),
+		IsDirectory:  false,
 	}
 
 	rq := &mpb.PutFileRequest{
-		Key:      f.name,
+		Path:     f.path,
 		File:     []byte(cres.Ciphertext),
 		Metadata: metadata,
 	}
-	_, err = f.parentDir.fuseServer.metadataServerClient.PutFile(ctx, rq)
-
+	_, err = f.fserver.metadataServerClient.PutFile(ctx, rq)
 	if err != nil {
-		return err // TODO(irfansharif): Propagate appropriate FUSE error.
+		return err
 	}
 
 	resp.Size = len(req.Data)
-	return nil
-}
-
-func (d *Dir) Remove(ctx context.Context, req *fuse.RemoveRequest) error {
-	d.fuseServer.mu.Lock()
-	defer d.fuseServer.mu.Unlock()
-
-	rq := &mpb.DeleteFileRequest{Key: req.Name}
-	_, err := d.fuseServer.metadataServerClient.DeleteFile(ctx, rq)
-	if err != nil {
-		return err // TODO(irfansharif): Propagate appropriate FUSE error.
-	}
-
 	return nil
 }

--- a/cmd/storage-server/server_test.go
+++ b/cmd/storage-server/server_test.go
@@ -52,57 +52,57 @@ func (t *testStore) Keys() []string {
 	return nil
 }
 
-func TestGetFile(t *testing.T) {
+func TestGetBlob(t *testing.T) {
 	logger := log.Discarder()
 	ctx := context.Background()
 
 	testStore := &testStore{}
 	storageServer := newStorageServer(logger, testStore)
-	req := &spb.GetFileRequest{Key: "get-file-req"}
-	res, err := storageServer.GetFile(ctx, req)
+	req := &spb.GetBlobRequest{Key: "get-blob-req"}
+	res, err := storageServer.GetBlob(ctx, req)
 	if err != nil {
 		t.Error(err)
 	}
 
-	if !bytes.Equal(res.File, testGetFileResp) {
-		t.Error(fmt.Sprintf("expected res.File = %v, got %v", testGetFileResp, res.File))
+	if !bytes.Equal(res.Data, testGetFileResp) {
+		t.Error(fmt.Sprintf("expected res.Data = %v, got %v", testGetFileResp, res.Data))
 	}
 }
 
-func TestPutFile(t *testing.T) {
+func TestPutData(t *testing.T) {
 	logger := log.Discarder()
 	ctx := context.Background()
 
 	testStore := &testStore{}
 	storageServer := newStorageServer(logger, testStore)
-	req := &spb.PutFileRequest{Key: "put-file-req", File: []byte("file")}
-	_, err := storageServer.PutFile(ctx, req)
-	if err != nil {
-		t.Error(err)
-	}
-}
-
-func TestDeleteFile(t *testing.T) {
-	logger := log.Discarder()
-	ctx := context.Background()
-
-	testStore := &testStore{}
-	storageServer := newStorageServer(logger, testStore)
-	req := &spb.DeleteFileRequest{Key: deleteFileReqKey}
-	_, err := storageServer.DeleteFile(ctx, req)
+	req := &spb.PutBlobRequest{Key: "put-data-req", Data: []byte("data")}
+	_, err := storageServer.PutBlob(ctx, req)
 	if err != nil {
 		t.Error(err)
 	}
 }
 
-func TestGetFileKeys(t *testing.T) {
+func TestDeleteBlob(t *testing.T) {
 	logger := log.Discarder()
 	ctx := context.Background()
 
 	testStore := &testStore{}
 	storageServer := newStorageServer(logger, testStore)
-	req := &spb.GetFileKeysRequest{}
-	_, err := storageServer.GetFileKeys(ctx, req)
+	req := &spb.DeleteBlobRequest{Key: deleteFileReqKey}
+	_, err := storageServer.DeleteBlob(ctx, req)
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func TestGetBlobKeys(t *testing.T) {
+	logger := log.Discarder()
+	ctx := context.Background()
+
+	testStore := &testStore{}
+	storageServer := newStorageServer(logger, testStore)
+	req := &spb.GetBlobKeysRequest{}
+	_, err := storageServer.GetBlobKeys(ctx, req)
 
 	if err != nil {
 		t.Error(err)

--- a/pkg/fuse/fs/serve.go
+++ b/pkg/fuse/fs/serve.go
@@ -904,7 +904,7 @@ func (c *Server) serve(r fuse.Request) {
 }
 
 // handleRequest will either a) call done(s) and r.Respond(s) OR b) return an error.
-func (c *Server) handleRequest(ctx context.Context, node Node, snode *serveNode, r fuse.Request, done func(resp interface{})) error {
+func (c *Server) handleRequest(ctx context.Context, node Node, snode *serveNode, r fuse.Request, done func(resp interface{})) (ERROR error) {
 	switch r := r.(type) {
 	default:
 		// Note: To FUSE, ENOSYS means "this server never implements this request."

--- a/pkg/pb/metadata/metadata.pb.go
+++ b/pkg/pb/metadata/metadata.pb.go
@@ -25,69 +25,77 @@ const _ = proto.ProtoPackageIsVersion2 // please upgrade the proto package
 
 // TODO (Franz): This should be encrypted; move this to the encryption
 // server when its implemented
-type FileMetadata struct {
-	Created              *FileMetadata_UnixTimestamp `protobuf:"bytes,1,opt,name=created,proto3" json:"created,omitempty"`
-	LastModified         *FileMetadata_UnixTimestamp `protobuf:"bytes,2,opt,name=last_modified,json=lastModified,proto3" json:"last_modified,omitempty"`
-	Permissions          uint32                      `protobuf:"varint,3,opt,name=permissions,proto3" json:"permissions,omitempty"`
-	Size                 int64                       `protobuf:"varint,4,opt,name=size,proto3" json:"size,omitempty"`
-	XXX_NoUnkeyedLiteral struct{}                    `json:"-"`
-	XXX_unrecognized     []byte                      `json:"-"`
-	XXX_sizecache        int32                       `json:"-"`
+type Metadata struct {
+	Created              *Metadata_UnixTimestamp `protobuf:"bytes,1,opt,name=created,proto3" json:"created,omitempty"`
+	LastModified         *Metadata_UnixTimestamp `protobuf:"bytes,2,opt,name=last_modified,json=lastModified,proto3" json:"last_modified,omitempty"`
+	Permissions          uint32                  `protobuf:"varint,3,opt,name=permissions,proto3" json:"permissions,omitempty"`
+	Size                 int64                   `protobuf:"varint,4,opt,name=size,proto3" json:"size,omitempty"`
+	IsDirectory          bool                    `protobuf:"varint,5,opt,name=is_directory,json=isDirectory,proto3" json:"is_directory,omitempty"`
+	XXX_NoUnkeyedLiteral struct{}                `json:"-"`
+	XXX_unrecognized     []byte                  `json:"-"`
+	XXX_sizecache        int32                   `json:"-"`
 }
 
-func (m *FileMetadata) Reset()         { *m = FileMetadata{} }
-func (m *FileMetadata) String() string { return proto.CompactTextString(m) }
-func (*FileMetadata) ProtoMessage()    {}
-func (*FileMetadata) Descriptor() ([]byte, []int) {
-	return fileDescriptor_metadata_87c2940c9e2f72d2, []int{0}
+func (m *Metadata) Reset()         { *m = Metadata{} }
+func (m *Metadata) String() string { return proto.CompactTextString(m) }
+func (*Metadata) ProtoMessage()    {}
+func (*Metadata) Descriptor() ([]byte, []int) {
+	return fileDescriptor_metadata_42681d185838b055, []int{0}
 }
-func (m *FileMetadata) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_FileMetadata.Unmarshal(m, b)
+func (m *Metadata) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_Metadata.Unmarshal(m, b)
 }
-func (m *FileMetadata) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_FileMetadata.Marshal(b, m, deterministic)
+func (m *Metadata) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_Metadata.Marshal(b, m, deterministic)
 }
-func (dst *FileMetadata) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_FileMetadata.Merge(dst, src)
+func (dst *Metadata) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_Metadata.Merge(dst, src)
 }
-func (m *FileMetadata) XXX_Size() int {
-	return xxx_messageInfo_FileMetadata.Size(m)
+func (m *Metadata) XXX_Size() int {
+	return xxx_messageInfo_Metadata.Size(m)
 }
-func (m *FileMetadata) XXX_DiscardUnknown() {
-	xxx_messageInfo_FileMetadata.DiscardUnknown(m)
+func (m *Metadata) XXX_DiscardUnknown() {
+	xxx_messageInfo_Metadata.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_FileMetadata proto.InternalMessageInfo
+var xxx_messageInfo_Metadata proto.InternalMessageInfo
 
-func (m *FileMetadata) GetCreated() *FileMetadata_UnixTimestamp {
+func (m *Metadata) GetCreated() *Metadata_UnixTimestamp {
 	if m != nil {
 		return m.Created
 	}
 	return nil
 }
 
-func (m *FileMetadata) GetLastModified() *FileMetadata_UnixTimestamp {
+func (m *Metadata) GetLastModified() *Metadata_UnixTimestamp {
 	if m != nil {
 		return m.LastModified
 	}
 	return nil
 }
 
-func (m *FileMetadata) GetPermissions() uint32 {
+func (m *Metadata) GetPermissions() uint32 {
 	if m != nil {
 		return m.Permissions
 	}
 	return 0
 }
 
-func (m *FileMetadata) GetSize() int64 {
+func (m *Metadata) GetSize() int64 {
 	if m != nil {
 		return m.Size
 	}
 	return 0
 }
 
-type FileMetadata_UnixTimestamp struct {
+func (m *Metadata) GetIsDirectory() bool {
+	if m != nil {
+		return m.IsDirectory
+	}
+	return false
+}
+
+type Metadata_UnixTimestamp struct {
 	Seconds              int64    `protobuf:"varint,1,opt,name=seconds,proto3" json:"seconds,omitempty"`
 	Nanoseconds          int64    `protobuf:"varint,2,opt,name=nanoseconds,proto3" json:"nanoseconds,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
@@ -95,266 +103,46 @@ type FileMetadata_UnixTimestamp struct {
 	XXX_sizecache        int32    `json:"-"`
 }
 
-func (m *FileMetadata_UnixTimestamp) Reset()         { *m = FileMetadata_UnixTimestamp{} }
-func (m *FileMetadata_UnixTimestamp) String() string { return proto.CompactTextString(m) }
-func (*FileMetadata_UnixTimestamp) ProtoMessage()    {}
-func (*FileMetadata_UnixTimestamp) Descriptor() ([]byte, []int) {
-	return fileDescriptor_metadata_87c2940c9e2f72d2, []int{0, 0}
+func (m *Metadata_UnixTimestamp) Reset()         { *m = Metadata_UnixTimestamp{} }
+func (m *Metadata_UnixTimestamp) String() string { return proto.CompactTextString(m) }
+func (*Metadata_UnixTimestamp) ProtoMessage()    {}
+func (*Metadata_UnixTimestamp) Descriptor() ([]byte, []int) {
+	return fileDescriptor_metadata_42681d185838b055, []int{0, 0}
 }
-func (m *FileMetadata_UnixTimestamp) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_FileMetadata_UnixTimestamp.Unmarshal(m, b)
+func (m *Metadata_UnixTimestamp) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_Metadata_UnixTimestamp.Unmarshal(m, b)
 }
-func (m *FileMetadata_UnixTimestamp) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_FileMetadata_UnixTimestamp.Marshal(b, m, deterministic)
+func (m *Metadata_UnixTimestamp) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_Metadata_UnixTimestamp.Marshal(b, m, deterministic)
 }
-func (dst *FileMetadata_UnixTimestamp) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_FileMetadata_UnixTimestamp.Merge(dst, src)
+func (dst *Metadata_UnixTimestamp) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_Metadata_UnixTimestamp.Merge(dst, src)
 }
-func (m *FileMetadata_UnixTimestamp) XXX_Size() int {
-	return xxx_messageInfo_FileMetadata_UnixTimestamp.Size(m)
+func (m *Metadata_UnixTimestamp) XXX_Size() int {
+	return xxx_messageInfo_Metadata_UnixTimestamp.Size(m)
 }
-func (m *FileMetadata_UnixTimestamp) XXX_DiscardUnknown() {
-	xxx_messageInfo_FileMetadata_UnixTimestamp.DiscardUnknown(m)
+func (m *Metadata_UnixTimestamp) XXX_DiscardUnknown() {
+	xxx_messageInfo_Metadata_UnixTimestamp.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_FileMetadata_UnixTimestamp proto.InternalMessageInfo
+var xxx_messageInfo_Metadata_UnixTimestamp proto.InternalMessageInfo
 
-func (m *FileMetadata_UnixTimestamp) GetSeconds() int64 {
+func (m *Metadata_UnixTimestamp) GetSeconds() int64 {
 	if m != nil {
 		return m.Seconds
 	}
 	return 0
 }
 
-func (m *FileMetadata_UnixTimestamp) GetNanoseconds() int64 {
+func (m *Metadata_UnixTimestamp) GetNanoseconds() int64 {
 	if m != nil {
 		return m.Nanoseconds
 	}
 	return 0
 }
 
-type GetDirectoryKeysRequest struct {
-	XXX_NoUnkeyedLiteral struct{} `json:"-"`
-	XXX_unrecognized     []byte   `json:"-"`
-	XXX_sizecache        int32    `json:"-"`
-}
-
-func (m *GetDirectoryKeysRequest) Reset()         { *m = GetDirectoryKeysRequest{} }
-func (m *GetDirectoryKeysRequest) String() string { return proto.CompactTextString(m) }
-func (*GetDirectoryKeysRequest) ProtoMessage()    {}
-func (*GetDirectoryKeysRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_metadata_87c2940c9e2f72d2, []int{1}
-}
-func (m *GetDirectoryKeysRequest) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_GetDirectoryKeysRequest.Unmarshal(m, b)
-}
-func (m *GetDirectoryKeysRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_GetDirectoryKeysRequest.Marshal(b, m, deterministic)
-}
-func (dst *GetDirectoryKeysRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_GetDirectoryKeysRequest.Merge(dst, src)
-}
-func (m *GetDirectoryKeysRequest) XXX_Size() int {
-	return xxx_messageInfo_GetDirectoryKeysRequest.Size(m)
-}
-func (m *GetDirectoryKeysRequest) XXX_DiscardUnknown() {
-	xxx_messageInfo_GetDirectoryKeysRequest.DiscardUnknown(m)
-}
-
-var xxx_messageInfo_GetDirectoryKeysRequest proto.InternalMessageInfo
-
-type GetDirectoryKeysResponse struct {
-	Keys                 []string `protobuf:"bytes,1,rep,name=keys,proto3" json:"keys,omitempty"`
-	XXX_NoUnkeyedLiteral struct{} `json:"-"`
-	XXX_unrecognized     []byte   `json:"-"`
-	XXX_sizecache        int32    `json:"-"`
-}
-
-func (m *GetDirectoryKeysResponse) Reset()         { *m = GetDirectoryKeysResponse{} }
-func (m *GetDirectoryKeysResponse) String() string { return proto.CompactTextString(m) }
-func (*GetDirectoryKeysResponse) ProtoMessage()    {}
-func (*GetDirectoryKeysResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_metadata_87c2940c9e2f72d2, []int{2}
-}
-func (m *GetDirectoryKeysResponse) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_GetDirectoryKeysResponse.Unmarshal(m, b)
-}
-func (m *GetDirectoryKeysResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_GetDirectoryKeysResponse.Marshal(b, m, deterministic)
-}
-func (dst *GetDirectoryKeysResponse) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_GetDirectoryKeysResponse.Merge(dst, src)
-}
-func (m *GetDirectoryKeysResponse) XXX_Size() int {
-	return xxx_messageInfo_GetDirectoryKeysResponse.Size(m)
-}
-func (m *GetDirectoryKeysResponse) XXX_DiscardUnknown() {
-	xxx_messageInfo_GetDirectoryKeysResponse.DiscardUnknown(m)
-}
-
-var xxx_messageInfo_GetDirectoryKeysResponse proto.InternalMessageInfo
-
-func (m *GetDirectoryKeysResponse) GetKeys() []string {
-	if m != nil {
-		return m.Keys
-	}
-	return nil
-}
-
-type GetMetadataRequest struct {
-	Key                  string   `protobuf:"bytes,1,opt,name=key,proto3" json:"key,omitempty"`
-	XXX_NoUnkeyedLiteral struct{} `json:"-"`
-	XXX_unrecognized     []byte   `json:"-"`
-	XXX_sizecache        int32    `json:"-"`
-}
-
-func (m *GetMetadataRequest) Reset()         { *m = GetMetadataRequest{} }
-func (m *GetMetadataRequest) String() string { return proto.CompactTextString(m) }
-func (*GetMetadataRequest) ProtoMessage()    {}
-func (*GetMetadataRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_metadata_87c2940c9e2f72d2, []int{3}
-}
-func (m *GetMetadataRequest) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_GetMetadataRequest.Unmarshal(m, b)
-}
-func (m *GetMetadataRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_GetMetadataRequest.Marshal(b, m, deterministic)
-}
-func (dst *GetMetadataRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_GetMetadataRequest.Merge(dst, src)
-}
-func (m *GetMetadataRequest) XXX_Size() int {
-	return xxx_messageInfo_GetMetadataRequest.Size(m)
-}
-func (m *GetMetadataRequest) XXX_DiscardUnknown() {
-	xxx_messageInfo_GetMetadataRequest.DiscardUnknown(m)
-}
-
-var xxx_messageInfo_GetMetadataRequest proto.InternalMessageInfo
-
-func (m *GetMetadataRequest) GetKey() string {
-	if m != nil {
-		return m.Key
-	}
-	return ""
-}
-
-type GetMetadataResponse struct {
-	Metadata             *FileMetadata `protobuf:"bytes,1,opt,name=metadata,proto3" json:"metadata,omitempty"`
-	XXX_NoUnkeyedLiteral struct{}      `json:"-"`
-	XXX_unrecognized     []byte        `json:"-"`
-	XXX_sizecache        int32         `json:"-"`
-}
-
-func (m *GetMetadataResponse) Reset()         { *m = GetMetadataResponse{} }
-func (m *GetMetadataResponse) String() string { return proto.CompactTextString(m) }
-func (*GetMetadataResponse) ProtoMessage()    {}
-func (*GetMetadataResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_metadata_87c2940c9e2f72d2, []int{4}
-}
-func (m *GetMetadataResponse) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_GetMetadataResponse.Unmarshal(m, b)
-}
-func (m *GetMetadataResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_GetMetadataResponse.Marshal(b, m, deterministic)
-}
-func (dst *GetMetadataResponse) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_GetMetadataResponse.Merge(dst, src)
-}
-func (m *GetMetadataResponse) XXX_Size() int {
-	return xxx_messageInfo_GetMetadataResponse.Size(m)
-}
-func (m *GetMetadataResponse) XXX_DiscardUnknown() {
-	xxx_messageInfo_GetMetadataResponse.DiscardUnknown(m)
-}
-
-var xxx_messageInfo_GetMetadataResponse proto.InternalMessageInfo
-
-func (m *GetMetadataResponse) GetMetadata() *FileMetadata {
-	if m != nil {
-		return m.Metadata
-	}
-	return nil
-}
-
-type SetMetadataRequest struct {
-	Key                  string        `protobuf:"bytes,1,opt,name=key,proto3" json:"key,omitempty"`
-	Metadata             *FileMetadata `protobuf:"bytes,2,opt,name=metadata,proto3" json:"metadata,omitempty"`
-	XXX_NoUnkeyedLiteral struct{}      `json:"-"`
-	XXX_unrecognized     []byte        `json:"-"`
-	XXX_sizecache        int32         `json:"-"`
-}
-
-func (m *SetMetadataRequest) Reset()         { *m = SetMetadataRequest{} }
-func (m *SetMetadataRequest) String() string { return proto.CompactTextString(m) }
-func (*SetMetadataRequest) ProtoMessage()    {}
-func (*SetMetadataRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_metadata_87c2940c9e2f72d2, []int{5}
-}
-func (m *SetMetadataRequest) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_SetMetadataRequest.Unmarshal(m, b)
-}
-func (m *SetMetadataRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_SetMetadataRequest.Marshal(b, m, deterministic)
-}
-func (dst *SetMetadataRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_SetMetadataRequest.Merge(dst, src)
-}
-func (m *SetMetadataRequest) XXX_Size() int {
-	return xxx_messageInfo_SetMetadataRequest.Size(m)
-}
-func (m *SetMetadataRequest) XXX_DiscardUnknown() {
-	xxx_messageInfo_SetMetadataRequest.DiscardUnknown(m)
-}
-
-var xxx_messageInfo_SetMetadataRequest proto.InternalMessageInfo
-
-func (m *SetMetadataRequest) GetKey() string {
-	if m != nil {
-		return m.Key
-	}
-	return ""
-}
-
-func (m *SetMetadataRequest) GetMetadata() *FileMetadata {
-	if m != nil {
-		return m.Metadata
-	}
-	return nil
-}
-
-type SetMetadataResponse struct {
-	XXX_NoUnkeyedLiteral struct{} `json:"-"`
-	XXX_unrecognized     []byte   `json:"-"`
-	XXX_sizecache        int32    `json:"-"`
-}
-
-func (m *SetMetadataResponse) Reset()         { *m = SetMetadataResponse{} }
-func (m *SetMetadataResponse) String() string { return proto.CompactTextString(m) }
-func (*SetMetadataResponse) ProtoMessage()    {}
-func (*SetMetadataResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_metadata_87c2940c9e2f72d2, []int{6}
-}
-func (m *SetMetadataResponse) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_SetMetadataResponse.Unmarshal(m, b)
-}
-func (m *SetMetadataResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_SetMetadataResponse.Marshal(b, m, deterministic)
-}
-func (dst *SetMetadataResponse) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_SetMetadataResponse.Merge(dst, src)
-}
-func (m *SetMetadataResponse) XXX_Size() int {
-	return xxx_messageInfo_SetMetadataResponse.Size(m)
-}
-func (m *SetMetadataResponse) XXX_DiscardUnknown() {
-	xxx_messageInfo_SetMetadataResponse.DiscardUnknown(m)
-}
-
-var xxx_messageInfo_SetMetadataResponse proto.InternalMessageInfo
-
 type GetFileRequest struct {
-	Key                  string   `protobuf:"bytes,1,opt,name=key,proto3" json:"key,omitempty"`
+	Path                 string   `protobuf:"bytes,1,opt,name=path,proto3" json:"path,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
@@ -364,7 +152,7 @@ func (m *GetFileRequest) Reset()         { *m = GetFileRequest{} }
 func (m *GetFileRequest) String() string { return proto.CompactTextString(m) }
 func (*GetFileRequest) ProtoMessage()    {}
 func (*GetFileRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_metadata_87c2940c9e2f72d2, []int{7}
+	return fileDescriptor_metadata_42681d185838b055, []int{1}
 }
 func (m *GetFileRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_GetFileRequest.Unmarshal(m, b)
@@ -384,26 +172,26 @@ func (m *GetFileRequest) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_GetFileRequest proto.InternalMessageInfo
 
-func (m *GetFileRequest) GetKey() string {
+func (m *GetFileRequest) GetPath() string {
 	if m != nil {
-		return m.Key
+		return m.Path
 	}
 	return ""
 }
 
 type GetFileResponse struct {
-	File                 []byte        `protobuf:"bytes,1,opt,name=file,proto3" json:"file,omitempty"`
-	Metadata             *FileMetadata `protobuf:"bytes,2,opt,name=metadata,proto3" json:"metadata,omitempty"`
-	XXX_NoUnkeyedLiteral struct{}      `json:"-"`
-	XXX_unrecognized     []byte        `json:"-"`
-	XXX_sizecache        int32         `json:"-"`
+	File                 []byte    `protobuf:"bytes,1,opt,name=file,proto3" json:"file,omitempty"`
+	Metadata             *Metadata `protobuf:"bytes,2,opt,name=metadata,proto3" json:"metadata,omitempty"`
+	XXX_NoUnkeyedLiteral struct{}  `json:"-"`
+	XXX_unrecognized     []byte    `json:"-"`
+	XXX_sizecache        int32     `json:"-"`
 }
 
 func (m *GetFileResponse) Reset()         { *m = GetFileResponse{} }
 func (m *GetFileResponse) String() string { return proto.CompactTextString(m) }
 func (*GetFileResponse) ProtoMessage()    {}
 func (*GetFileResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_metadata_87c2940c9e2f72d2, []int{8}
+	return fileDescriptor_metadata_42681d185838b055, []int{2}
 }
 func (m *GetFileResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_GetFileResponse.Unmarshal(m, b)
@@ -430,7 +218,7 @@ func (m *GetFileResponse) GetFile() []byte {
 	return nil
 }
 
-func (m *GetFileResponse) GetMetadata() *FileMetadata {
+func (m *GetFileResponse) GetMetadata() *Metadata {
 	if m != nil {
 		return m.Metadata
 	}
@@ -438,19 +226,19 @@ func (m *GetFileResponse) GetMetadata() *FileMetadata {
 }
 
 type PutFileRequest struct {
-	Key                  string        `protobuf:"bytes,1,opt,name=key,proto3" json:"key,omitempty"`
-	File                 []byte        `protobuf:"bytes,2,opt,name=file,proto3" json:"file,omitempty"`
-	Metadata             *FileMetadata `protobuf:"bytes,3,opt,name=metadata,proto3" json:"metadata,omitempty"`
-	XXX_NoUnkeyedLiteral struct{}      `json:"-"`
-	XXX_unrecognized     []byte        `json:"-"`
-	XXX_sizecache        int32         `json:"-"`
+	Path                 string    `protobuf:"bytes,1,opt,name=path,proto3" json:"path,omitempty"`
+	File                 []byte    `protobuf:"bytes,2,opt,name=file,proto3" json:"file,omitempty"`
+	Metadata             *Metadata `protobuf:"bytes,3,opt,name=metadata,proto3" json:"metadata,omitempty"`
+	XXX_NoUnkeyedLiteral struct{}  `json:"-"`
+	XXX_unrecognized     []byte    `json:"-"`
+	XXX_sizecache        int32     `json:"-"`
 }
 
 func (m *PutFileRequest) Reset()         { *m = PutFileRequest{} }
 func (m *PutFileRequest) String() string { return proto.CompactTextString(m) }
 func (*PutFileRequest) ProtoMessage()    {}
 func (*PutFileRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_metadata_87c2940c9e2f72d2, []int{9}
+	return fileDescriptor_metadata_42681d185838b055, []int{3}
 }
 func (m *PutFileRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_PutFileRequest.Unmarshal(m, b)
@@ -470,9 +258,9 @@ func (m *PutFileRequest) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_PutFileRequest proto.InternalMessageInfo
 
-func (m *PutFileRequest) GetKey() string {
+func (m *PutFileRequest) GetPath() string {
 	if m != nil {
-		return m.Key
+		return m.Path
 	}
 	return ""
 }
@@ -484,7 +272,7 @@ func (m *PutFileRequest) GetFile() []byte {
 	return nil
 }
 
-func (m *PutFileRequest) GetMetadata() *FileMetadata {
+func (m *PutFileRequest) GetMetadata() *Metadata {
 	if m != nil {
 		return m.Metadata
 	}
@@ -501,7 +289,7 @@ func (m *PutFileResponse) Reset()         { *m = PutFileResponse{} }
 func (m *PutFileResponse) String() string { return proto.CompactTextString(m) }
 func (*PutFileResponse) ProtoMessage()    {}
 func (*PutFileResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_metadata_87c2940c9e2f72d2, []int{10}
+	return fileDescriptor_metadata_42681d185838b055, []int{4}
 }
 func (m *PutFileResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_PutFileResponse.Unmarshal(m, b)
@@ -522,7 +310,7 @@ func (m *PutFileResponse) XXX_DiscardUnknown() {
 var xxx_messageInfo_PutFileResponse proto.InternalMessageInfo
 
 type DeleteFileRequest struct {
-	Key                  string   `protobuf:"bytes,1,opt,name=key,proto3" json:"key,omitempty"`
+	Path                 string   `protobuf:"bytes,1,opt,name=path,proto3" json:"path,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
@@ -532,7 +320,7 @@ func (m *DeleteFileRequest) Reset()         { *m = DeleteFileRequest{} }
 func (m *DeleteFileRequest) String() string { return proto.CompactTextString(m) }
 func (*DeleteFileRequest) ProtoMessage()    {}
 func (*DeleteFileRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_metadata_87c2940c9e2f72d2, []int{11}
+	return fileDescriptor_metadata_42681d185838b055, []int{5}
 }
 func (m *DeleteFileRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_DeleteFileRequest.Unmarshal(m, b)
@@ -552,9 +340,9 @@ func (m *DeleteFileRequest) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_DeleteFileRequest proto.InternalMessageInfo
 
-func (m *DeleteFileRequest) GetKey() string {
+func (m *DeleteFileRequest) GetPath() string {
 	if m != nil {
-		return m.Key
+		return m.Path
 	}
 	return ""
 }
@@ -569,7 +357,7 @@ func (m *DeleteFileResponse) Reset()         { *m = DeleteFileResponse{} }
 func (m *DeleteFileResponse) String() string { return proto.CompactTextString(m) }
 func (*DeleteFileResponse) ProtoMessage()    {}
 func (*DeleteFileResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_metadata_87c2940c9e2f72d2, []int{12}
+	return fileDescriptor_metadata_42681d185838b055, []int{6}
 }
 func (m *DeleteFileResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_DeleteFileResponse.Unmarshal(m, b)
@@ -589,21 +377,448 @@ func (m *DeleteFileResponse) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_DeleteFileResponse proto.InternalMessageInfo
 
+type GetDirectoryEntriesRequest struct {
+	Path                 string   `protobuf:"bytes,1,opt,name=path,proto3" json:"path,omitempty"`
+	XXX_NoUnkeyedLiteral struct{} `json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
+	XXX_sizecache        int32    `json:"-"`
+}
+
+func (m *GetDirectoryEntriesRequest) Reset()         { *m = GetDirectoryEntriesRequest{} }
+func (m *GetDirectoryEntriesRequest) String() string { return proto.CompactTextString(m) }
+func (*GetDirectoryEntriesRequest) ProtoMessage()    {}
+func (*GetDirectoryEntriesRequest) Descriptor() ([]byte, []int) {
+	return fileDescriptor_metadata_42681d185838b055, []int{7}
+}
+func (m *GetDirectoryEntriesRequest) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_GetDirectoryEntriesRequest.Unmarshal(m, b)
+}
+func (m *GetDirectoryEntriesRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_GetDirectoryEntriesRequest.Marshal(b, m, deterministic)
+}
+func (dst *GetDirectoryEntriesRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_GetDirectoryEntriesRequest.Merge(dst, src)
+}
+func (m *GetDirectoryEntriesRequest) XXX_Size() int {
+	return xxx_messageInfo_GetDirectoryEntriesRequest.Size(m)
+}
+func (m *GetDirectoryEntriesRequest) XXX_DiscardUnknown() {
+	xxx_messageInfo_GetDirectoryEntriesRequest.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_GetDirectoryEntriesRequest proto.InternalMessageInfo
+
+func (m *GetDirectoryEntriesRequest) GetPath() string {
+	if m != nil {
+		return m.Path
+	}
+	return ""
+}
+
+type GetDirectoryEntriesResponse struct {
+	Entries              []*GetDirectoryEntriesResponse_DirectoryEntry `protobuf:"bytes,1,rep,name=entries,proto3" json:"entries,omitempty"`
+	XXX_NoUnkeyedLiteral struct{}                                      `json:"-"`
+	XXX_unrecognized     []byte                                        `json:"-"`
+	XXX_sizecache        int32                                         `json:"-"`
+}
+
+func (m *GetDirectoryEntriesResponse) Reset()         { *m = GetDirectoryEntriesResponse{} }
+func (m *GetDirectoryEntriesResponse) String() string { return proto.CompactTextString(m) }
+func (*GetDirectoryEntriesResponse) ProtoMessage()    {}
+func (*GetDirectoryEntriesResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_metadata_42681d185838b055, []int{8}
+}
+func (m *GetDirectoryEntriesResponse) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_GetDirectoryEntriesResponse.Unmarshal(m, b)
+}
+func (m *GetDirectoryEntriesResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_GetDirectoryEntriesResponse.Marshal(b, m, deterministic)
+}
+func (dst *GetDirectoryEntriesResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_GetDirectoryEntriesResponse.Merge(dst, src)
+}
+func (m *GetDirectoryEntriesResponse) XXX_Size() int {
+	return xxx_messageInfo_GetDirectoryEntriesResponse.Size(m)
+}
+func (m *GetDirectoryEntriesResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_GetDirectoryEntriesResponse.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_GetDirectoryEntriesResponse proto.InternalMessageInfo
+
+func (m *GetDirectoryEntriesResponse) GetEntries() []*GetDirectoryEntriesResponse_DirectoryEntry {
+	if m != nil {
+		return m.Entries
+	}
+	return nil
+}
+
+type GetDirectoryEntriesResponse_DirectoryEntry struct {
+	Path                 string   `protobuf:"bytes,1,opt,name=path,proto3" json:"path,omitempty"`
+	IsDirectory          bool     `protobuf:"varint,2,opt,name=is_directory,json=isDirectory,proto3" json:"is_directory,omitempty"`
+	XXX_NoUnkeyedLiteral struct{} `json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
+	XXX_sizecache        int32    `json:"-"`
+}
+
+func (m *GetDirectoryEntriesResponse_DirectoryEntry) Reset() {
+	*m = GetDirectoryEntriesResponse_DirectoryEntry{}
+}
+func (m *GetDirectoryEntriesResponse_DirectoryEntry) String() string {
+	return proto.CompactTextString(m)
+}
+func (*GetDirectoryEntriesResponse_DirectoryEntry) ProtoMessage() {}
+func (*GetDirectoryEntriesResponse_DirectoryEntry) Descriptor() ([]byte, []int) {
+	return fileDescriptor_metadata_42681d185838b055, []int{8, 0}
+}
+func (m *GetDirectoryEntriesResponse_DirectoryEntry) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_GetDirectoryEntriesResponse_DirectoryEntry.Unmarshal(m, b)
+}
+func (m *GetDirectoryEntriesResponse_DirectoryEntry) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_GetDirectoryEntriesResponse_DirectoryEntry.Marshal(b, m, deterministic)
+}
+func (dst *GetDirectoryEntriesResponse_DirectoryEntry) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_GetDirectoryEntriesResponse_DirectoryEntry.Merge(dst, src)
+}
+func (m *GetDirectoryEntriesResponse_DirectoryEntry) XXX_Size() int {
+	return xxx_messageInfo_GetDirectoryEntriesResponse_DirectoryEntry.Size(m)
+}
+func (m *GetDirectoryEntriesResponse_DirectoryEntry) XXX_DiscardUnknown() {
+	xxx_messageInfo_GetDirectoryEntriesResponse_DirectoryEntry.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_GetDirectoryEntriesResponse_DirectoryEntry proto.InternalMessageInfo
+
+func (m *GetDirectoryEntriesResponse_DirectoryEntry) GetPath() string {
+	if m != nil {
+		return m.Path
+	}
+	return ""
+}
+
+func (m *GetDirectoryEntriesResponse_DirectoryEntry) GetIsDirectory() bool {
+	if m != nil {
+		return m.IsDirectory
+	}
+	return false
+}
+
+type CreateDirectoryRequest struct {
+	Path                 string    `protobuf:"bytes,1,opt,name=path,proto3" json:"path,omitempty"`
+	Metadata             *Metadata `protobuf:"bytes,2,opt,name=metadata,proto3" json:"metadata,omitempty"`
+	XXX_NoUnkeyedLiteral struct{}  `json:"-"`
+	XXX_unrecognized     []byte    `json:"-"`
+	XXX_sizecache        int32     `json:"-"`
+}
+
+func (m *CreateDirectoryRequest) Reset()         { *m = CreateDirectoryRequest{} }
+func (m *CreateDirectoryRequest) String() string { return proto.CompactTextString(m) }
+func (*CreateDirectoryRequest) ProtoMessage()    {}
+func (*CreateDirectoryRequest) Descriptor() ([]byte, []int) {
+	return fileDescriptor_metadata_42681d185838b055, []int{9}
+}
+func (m *CreateDirectoryRequest) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_CreateDirectoryRequest.Unmarshal(m, b)
+}
+func (m *CreateDirectoryRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_CreateDirectoryRequest.Marshal(b, m, deterministic)
+}
+func (dst *CreateDirectoryRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_CreateDirectoryRequest.Merge(dst, src)
+}
+func (m *CreateDirectoryRequest) XXX_Size() int {
+	return xxx_messageInfo_CreateDirectoryRequest.Size(m)
+}
+func (m *CreateDirectoryRequest) XXX_DiscardUnknown() {
+	xxx_messageInfo_CreateDirectoryRequest.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_CreateDirectoryRequest proto.InternalMessageInfo
+
+func (m *CreateDirectoryRequest) GetPath() string {
+	if m != nil {
+		return m.Path
+	}
+	return ""
+}
+
+func (m *CreateDirectoryRequest) GetMetadata() *Metadata {
+	if m != nil {
+		return m.Metadata
+	}
+	return nil
+}
+
+type CreateDirectoryResponse struct {
+	XXX_NoUnkeyedLiteral struct{} `json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
+	XXX_sizecache        int32    `json:"-"`
+}
+
+func (m *CreateDirectoryResponse) Reset()         { *m = CreateDirectoryResponse{} }
+func (m *CreateDirectoryResponse) String() string { return proto.CompactTextString(m) }
+func (*CreateDirectoryResponse) ProtoMessage()    {}
+func (*CreateDirectoryResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_metadata_42681d185838b055, []int{10}
+}
+func (m *CreateDirectoryResponse) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_CreateDirectoryResponse.Unmarshal(m, b)
+}
+func (m *CreateDirectoryResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_CreateDirectoryResponse.Marshal(b, m, deterministic)
+}
+func (dst *CreateDirectoryResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_CreateDirectoryResponse.Merge(dst, src)
+}
+func (m *CreateDirectoryResponse) XXX_Size() int {
+	return xxx_messageInfo_CreateDirectoryResponse.Size(m)
+}
+func (m *CreateDirectoryResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_CreateDirectoryResponse.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_CreateDirectoryResponse proto.InternalMessageInfo
+
+type DeleteDirectoryRequest struct {
+	Path                 string   `protobuf:"bytes,1,opt,name=path,proto3" json:"path,omitempty"`
+	XXX_NoUnkeyedLiteral struct{} `json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
+	XXX_sizecache        int32    `json:"-"`
+}
+
+func (m *DeleteDirectoryRequest) Reset()         { *m = DeleteDirectoryRequest{} }
+func (m *DeleteDirectoryRequest) String() string { return proto.CompactTextString(m) }
+func (*DeleteDirectoryRequest) ProtoMessage()    {}
+func (*DeleteDirectoryRequest) Descriptor() ([]byte, []int) {
+	return fileDescriptor_metadata_42681d185838b055, []int{11}
+}
+func (m *DeleteDirectoryRequest) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_DeleteDirectoryRequest.Unmarshal(m, b)
+}
+func (m *DeleteDirectoryRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_DeleteDirectoryRequest.Marshal(b, m, deterministic)
+}
+func (dst *DeleteDirectoryRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_DeleteDirectoryRequest.Merge(dst, src)
+}
+func (m *DeleteDirectoryRequest) XXX_Size() int {
+	return xxx_messageInfo_DeleteDirectoryRequest.Size(m)
+}
+func (m *DeleteDirectoryRequest) XXX_DiscardUnknown() {
+	xxx_messageInfo_DeleteDirectoryRequest.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_DeleteDirectoryRequest proto.InternalMessageInfo
+
+func (m *DeleteDirectoryRequest) GetPath() string {
+	if m != nil {
+		return m.Path
+	}
+	return ""
+}
+
+type DeleteDirectoryResponse struct {
+	XXX_NoUnkeyedLiteral struct{} `json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
+	XXX_sizecache        int32    `json:"-"`
+}
+
+func (m *DeleteDirectoryResponse) Reset()         { *m = DeleteDirectoryResponse{} }
+func (m *DeleteDirectoryResponse) String() string { return proto.CompactTextString(m) }
+func (*DeleteDirectoryResponse) ProtoMessage()    {}
+func (*DeleteDirectoryResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_metadata_42681d185838b055, []int{12}
+}
+func (m *DeleteDirectoryResponse) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_DeleteDirectoryResponse.Unmarshal(m, b)
+}
+func (m *DeleteDirectoryResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_DeleteDirectoryResponse.Marshal(b, m, deterministic)
+}
+func (dst *DeleteDirectoryResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_DeleteDirectoryResponse.Merge(dst, src)
+}
+func (m *DeleteDirectoryResponse) XXX_Size() int {
+	return xxx_messageInfo_DeleteDirectoryResponse.Size(m)
+}
+func (m *DeleteDirectoryResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_DeleteDirectoryResponse.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_DeleteDirectoryResponse proto.InternalMessageInfo
+
+type GetMetadataRequest struct {
+	Path                 string   `protobuf:"bytes,1,opt,name=path,proto3" json:"path,omitempty"`
+	XXX_NoUnkeyedLiteral struct{} `json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
+	XXX_sizecache        int32    `json:"-"`
+}
+
+func (m *GetMetadataRequest) Reset()         { *m = GetMetadataRequest{} }
+func (m *GetMetadataRequest) String() string { return proto.CompactTextString(m) }
+func (*GetMetadataRequest) ProtoMessage()    {}
+func (*GetMetadataRequest) Descriptor() ([]byte, []int) {
+	return fileDescriptor_metadata_42681d185838b055, []int{13}
+}
+func (m *GetMetadataRequest) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_GetMetadataRequest.Unmarshal(m, b)
+}
+func (m *GetMetadataRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_GetMetadataRequest.Marshal(b, m, deterministic)
+}
+func (dst *GetMetadataRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_GetMetadataRequest.Merge(dst, src)
+}
+func (m *GetMetadataRequest) XXX_Size() int {
+	return xxx_messageInfo_GetMetadataRequest.Size(m)
+}
+func (m *GetMetadataRequest) XXX_DiscardUnknown() {
+	xxx_messageInfo_GetMetadataRequest.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_GetMetadataRequest proto.InternalMessageInfo
+
+func (m *GetMetadataRequest) GetPath() string {
+	if m != nil {
+		return m.Path
+	}
+	return ""
+}
+
+type GetMetadataResponse struct {
+	Metadata             *Metadata `protobuf:"bytes,1,opt,name=metadata,proto3" json:"metadata,omitempty"`
+	XXX_NoUnkeyedLiteral struct{}  `json:"-"`
+	XXX_unrecognized     []byte    `json:"-"`
+	XXX_sizecache        int32     `json:"-"`
+}
+
+func (m *GetMetadataResponse) Reset()         { *m = GetMetadataResponse{} }
+func (m *GetMetadataResponse) String() string { return proto.CompactTextString(m) }
+func (*GetMetadataResponse) ProtoMessage()    {}
+func (*GetMetadataResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_metadata_42681d185838b055, []int{14}
+}
+func (m *GetMetadataResponse) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_GetMetadataResponse.Unmarshal(m, b)
+}
+func (m *GetMetadataResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_GetMetadataResponse.Marshal(b, m, deterministic)
+}
+func (dst *GetMetadataResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_GetMetadataResponse.Merge(dst, src)
+}
+func (m *GetMetadataResponse) XXX_Size() int {
+	return xxx_messageInfo_GetMetadataResponse.Size(m)
+}
+func (m *GetMetadataResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_GetMetadataResponse.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_GetMetadataResponse proto.InternalMessageInfo
+
+func (m *GetMetadataResponse) GetMetadata() *Metadata {
+	if m != nil {
+		return m.Metadata
+	}
+	return nil
+}
+
+type SetMetadataRequest struct {
+	Path                 string    `protobuf:"bytes,1,opt,name=path,proto3" json:"path,omitempty"`
+	Metadata             *Metadata `protobuf:"bytes,2,opt,name=metadata,proto3" json:"metadata,omitempty"`
+	XXX_NoUnkeyedLiteral struct{}  `json:"-"`
+	XXX_unrecognized     []byte    `json:"-"`
+	XXX_sizecache        int32     `json:"-"`
+}
+
+func (m *SetMetadataRequest) Reset()         { *m = SetMetadataRequest{} }
+func (m *SetMetadataRequest) String() string { return proto.CompactTextString(m) }
+func (*SetMetadataRequest) ProtoMessage()    {}
+func (*SetMetadataRequest) Descriptor() ([]byte, []int) {
+	return fileDescriptor_metadata_42681d185838b055, []int{15}
+}
+func (m *SetMetadataRequest) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_SetMetadataRequest.Unmarshal(m, b)
+}
+func (m *SetMetadataRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_SetMetadataRequest.Marshal(b, m, deterministic)
+}
+func (dst *SetMetadataRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_SetMetadataRequest.Merge(dst, src)
+}
+func (m *SetMetadataRequest) XXX_Size() int {
+	return xxx_messageInfo_SetMetadataRequest.Size(m)
+}
+func (m *SetMetadataRequest) XXX_DiscardUnknown() {
+	xxx_messageInfo_SetMetadataRequest.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_SetMetadataRequest proto.InternalMessageInfo
+
+func (m *SetMetadataRequest) GetPath() string {
+	if m != nil {
+		return m.Path
+	}
+	return ""
+}
+
+func (m *SetMetadataRequest) GetMetadata() *Metadata {
+	if m != nil {
+		return m.Metadata
+	}
+	return nil
+}
+
+type SetMetadataResponse struct {
+	XXX_NoUnkeyedLiteral struct{} `json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
+	XXX_sizecache        int32    `json:"-"`
+}
+
+func (m *SetMetadataResponse) Reset()         { *m = SetMetadataResponse{} }
+func (m *SetMetadataResponse) String() string { return proto.CompactTextString(m) }
+func (*SetMetadataResponse) ProtoMessage()    {}
+func (*SetMetadataResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_metadata_42681d185838b055, []int{16}
+}
+func (m *SetMetadataResponse) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_SetMetadataResponse.Unmarshal(m, b)
+}
+func (m *SetMetadataResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_SetMetadataResponse.Marshal(b, m, deterministic)
+}
+func (dst *SetMetadataResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_SetMetadataResponse.Merge(dst, src)
+}
+func (m *SetMetadataResponse) XXX_Size() int {
+	return xxx_messageInfo_SetMetadataResponse.Size(m)
+}
+func (m *SetMetadataResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_SetMetadataResponse.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_SetMetadataResponse proto.InternalMessageInfo
+
 func init() {
-	proto.RegisterType((*FileMetadata)(nil), "metadata.FileMetadata")
-	proto.RegisterType((*FileMetadata_UnixTimestamp)(nil), "metadata.FileMetadata.UnixTimestamp")
-	proto.RegisterType((*GetDirectoryKeysRequest)(nil), "metadata.GetDirectoryKeysRequest")
-	proto.RegisterType((*GetDirectoryKeysResponse)(nil), "metadata.GetDirectoryKeysResponse")
-	proto.RegisterType((*GetMetadataRequest)(nil), "metadata.GetMetadataRequest")
-	proto.RegisterType((*GetMetadataResponse)(nil), "metadata.GetMetadataResponse")
-	proto.RegisterType((*SetMetadataRequest)(nil), "metadata.SetMetadataRequest")
-	proto.RegisterType((*SetMetadataResponse)(nil), "metadata.SetMetadataResponse")
+	proto.RegisterType((*Metadata)(nil), "metadata.Metadata")
+	proto.RegisterType((*Metadata_UnixTimestamp)(nil), "metadata.Metadata.UnixTimestamp")
 	proto.RegisterType((*GetFileRequest)(nil), "metadata.GetFileRequest")
 	proto.RegisterType((*GetFileResponse)(nil), "metadata.GetFileResponse")
 	proto.RegisterType((*PutFileRequest)(nil), "metadata.PutFileRequest")
 	proto.RegisterType((*PutFileResponse)(nil), "metadata.PutFileResponse")
 	proto.RegisterType((*DeleteFileRequest)(nil), "metadata.DeleteFileRequest")
 	proto.RegisterType((*DeleteFileResponse)(nil), "metadata.DeleteFileResponse")
+	proto.RegisterType((*GetDirectoryEntriesRequest)(nil), "metadata.GetDirectoryEntriesRequest")
+	proto.RegisterType((*GetDirectoryEntriesResponse)(nil), "metadata.GetDirectoryEntriesResponse")
+	proto.RegisterType((*GetDirectoryEntriesResponse_DirectoryEntry)(nil), "metadata.GetDirectoryEntriesResponse.DirectoryEntry")
+	proto.RegisterType((*CreateDirectoryRequest)(nil), "metadata.CreateDirectoryRequest")
+	proto.RegisterType((*CreateDirectoryResponse)(nil), "metadata.CreateDirectoryResponse")
+	proto.RegisterType((*DeleteDirectoryRequest)(nil), "metadata.DeleteDirectoryRequest")
+	proto.RegisterType((*DeleteDirectoryResponse)(nil), "metadata.DeleteDirectoryResponse")
+	proto.RegisterType((*GetMetadataRequest)(nil), "metadata.GetMetadataRequest")
+	proto.RegisterType((*GetMetadataResponse)(nil), "metadata.GetMetadataResponse")
+	proto.RegisterType((*SetMetadataRequest)(nil), "metadata.SetMetadataRequest")
+	proto.RegisterType((*SetMetadataResponse)(nil), "metadata.SetMetadataResponse")
 }
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -621,9 +836,11 @@ type MetadataServiceClient interface {
 	GetFile(ctx context.Context, in *GetFileRequest, opts ...grpc.CallOption) (*GetFileResponse, error)
 	PutFile(ctx context.Context, in *PutFileRequest, opts ...grpc.CallOption) (*PutFileResponse, error)
 	DeleteFile(ctx context.Context, in *DeleteFileRequest, opts ...grpc.CallOption) (*DeleteFileResponse, error)
+	CreateDirectory(ctx context.Context, in *CreateDirectoryRequest, opts ...grpc.CallOption) (*CreateDirectoryResponse, error)
+	DeleteDirectory(ctx context.Context, in *DeleteDirectoryRequest, opts ...grpc.CallOption) (*DeleteDirectoryResponse, error)
+	GetDirectoryEntries(ctx context.Context, in *GetDirectoryEntriesRequest, opts ...grpc.CallOption) (*GetDirectoryEntriesResponse, error)
 	GetMetadata(ctx context.Context, in *GetMetadataRequest, opts ...grpc.CallOption) (*GetMetadataResponse, error)
 	SetMetadata(ctx context.Context, in *SetMetadataRequest, opts ...grpc.CallOption) (*SetMetadataResponse, error)
-	GetDirectoryKeys(ctx context.Context, in *GetDirectoryKeysRequest, opts ...grpc.CallOption) (*GetDirectoryKeysResponse, error)
 }
 
 type metadataServiceClient struct {
@@ -661,6 +878,33 @@ func (c *metadataServiceClient) DeleteFile(ctx context.Context, in *DeleteFileRe
 	return out, nil
 }
 
+func (c *metadataServiceClient) CreateDirectory(ctx context.Context, in *CreateDirectoryRequest, opts ...grpc.CallOption) (*CreateDirectoryResponse, error) {
+	out := new(CreateDirectoryResponse)
+	err := c.cc.Invoke(ctx, "/metadata.MetadataService/CreateDirectory", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *metadataServiceClient) DeleteDirectory(ctx context.Context, in *DeleteDirectoryRequest, opts ...grpc.CallOption) (*DeleteDirectoryResponse, error) {
+	out := new(DeleteDirectoryResponse)
+	err := c.cc.Invoke(ctx, "/metadata.MetadataService/DeleteDirectory", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *metadataServiceClient) GetDirectoryEntries(ctx context.Context, in *GetDirectoryEntriesRequest, opts ...grpc.CallOption) (*GetDirectoryEntriesResponse, error) {
+	out := new(GetDirectoryEntriesResponse)
+	err := c.cc.Invoke(ctx, "/metadata.MetadataService/GetDirectoryEntries", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 func (c *metadataServiceClient) GetMetadata(ctx context.Context, in *GetMetadataRequest, opts ...grpc.CallOption) (*GetMetadataResponse, error) {
 	out := new(GetMetadataResponse)
 	err := c.cc.Invoke(ctx, "/metadata.MetadataService/GetMetadata", in, out, opts...)
@@ -679,23 +923,16 @@ func (c *metadataServiceClient) SetMetadata(ctx context.Context, in *SetMetadata
 	return out, nil
 }
 
-func (c *metadataServiceClient) GetDirectoryKeys(ctx context.Context, in *GetDirectoryKeysRequest, opts ...grpc.CallOption) (*GetDirectoryKeysResponse, error) {
-	out := new(GetDirectoryKeysResponse)
-	err := c.cc.Invoke(ctx, "/metadata.MetadataService/GetDirectoryKeys", in, out, opts...)
-	if err != nil {
-		return nil, err
-	}
-	return out, nil
-}
-
 // MetadataServiceServer is the server API for MetadataService service.
 type MetadataServiceServer interface {
 	GetFile(context.Context, *GetFileRequest) (*GetFileResponse, error)
 	PutFile(context.Context, *PutFileRequest) (*PutFileResponse, error)
 	DeleteFile(context.Context, *DeleteFileRequest) (*DeleteFileResponse, error)
+	CreateDirectory(context.Context, *CreateDirectoryRequest) (*CreateDirectoryResponse, error)
+	DeleteDirectory(context.Context, *DeleteDirectoryRequest) (*DeleteDirectoryResponse, error)
+	GetDirectoryEntries(context.Context, *GetDirectoryEntriesRequest) (*GetDirectoryEntriesResponse, error)
 	GetMetadata(context.Context, *GetMetadataRequest) (*GetMetadataResponse, error)
 	SetMetadata(context.Context, *SetMetadataRequest) (*SetMetadataResponse, error)
-	GetDirectoryKeys(context.Context, *GetDirectoryKeysRequest) (*GetDirectoryKeysResponse, error)
 }
 
 func RegisterMetadataServiceServer(s *grpc.Server, srv MetadataServiceServer) {
@@ -756,6 +993,60 @@ func _MetadataService_DeleteFile_Handler(srv interface{}, ctx context.Context, d
 	return interceptor(ctx, in, info, handler)
 }
 
+func _MetadataService_CreateDirectory_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(CreateDirectoryRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(MetadataServiceServer).CreateDirectory(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/metadata.MetadataService/CreateDirectory",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(MetadataServiceServer).CreateDirectory(ctx, req.(*CreateDirectoryRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _MetadataService_DeleteDirectory_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(DeleteDirectoryRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(MetadataServiceServer).DeleteDirectory(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/metadata.MetadataService/DeleteDirectory",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(MetadataServiceServer).DeleteDirectory(ctx, req.(*DeleteDirectoryRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _MetadataService_GetDirectoryEntries_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(GetDirectoryEntriesRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(MetadataServiceServer).GetDirectoryEntries(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/metadata.MetadataService/GetDirectoryEntries",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(MetadataServiceServer).GetDirectoryEntries(ctx, req.(*GetDirectoryEntriesRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 func _MetadataService_GetMetadata_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(GetMetadataRequest)
 	if err := dec(in); err != nil {
@@ -792,24 +1083,6 @@ func _MetadataService_SetMetadata_Handler(srv interface{}, ctx context.Context, 
 	return interceptor(ctx, in, info, handler)
 }
 
-func _MetadataService_GetDirectoryKeys_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(GetDirectoryKeysRequest)
-	if err := dec(in); err != nil {
-		return nil, err
-	}
-	if interceptor == nil {
-		return srv.(MetadataServiceServer).GetDirectoryKeys(ctx, in)
-	}
-	info := &grpc.UnaryServerInfo{
-		Server:     srv,
-		FullMethod: "/metadata.MetadataService/GetDirectoryKeys",
-	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(MetadataServiceServer).GetDirectoryKeys(ctx, req.(*GetDirectoryKeysRequest))
-	}
-	return interceptor(ctx, in, info, handler)
-}
-
 var _MetadataService_serviceDesc = grpc.ServiceDesc{
 	ServiceName: "metadata.MetadataService",
 	HandlerType: (*MetadataServiceServer)(nil),
@@ -827,6 +1100,18 @@ var _MetadataService_serviceDesc = grpc.ServiceDesc{
 			Handler:    _MetadataService_DeleteFile_Handler,
 		},
 		{
+			MethodName: "CreateDirectory",
+			Handler:    _MetadataService_CreateDirectory_Handler,
+		},
+		{
+			MethodName: "DeleteDirectory",
+			Handler:    _MetadataService_DeleteDirectory_Handler,
+		},
+		{
+			MethodName: "GetDirectoryEntries",
+			Handler:    _MetadataService_GetDirectoryEntries_Handler,
+		},
+		{
 			MethodName: "GetMetadata",
 			Handler:    _MetadataService_GetMetadata_Handler,
 		},
@@ -834,47 +1119,50 @@ var _MetadataService_serviceDesc = grpc.ServiceDesc{
 			MethodName: "SetMetadata",
 			Handler:    _MetadataService_SetMetadata_Handler,
 		},
-		{
-			MethodName: "GetDirectoryKeys",
-			Handler:    _MetadataService_GetDirectoryKeys_Handler,
-		},
 	},
 	Streams:  []grpc.StreamDesc{},
 	Metadata: "metadata.proto",
 }
 
-func init() { proto.RegisterFile("metadata.proto", fileDescriptor_metadata_87c2940c9e2f72d2) }
+func init() { proto.RegisterFile("metadata.proto", fileDescriptor_metadata_42681d185838b055) }
 
-var fileDescriptor_metadata_87c2940c9e2f72d2 = []byte{
-	// 478 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x9c, 0x54, 0x5b, 0x6f, 0xd3, 0x30,
-	0x14, 0x56, 0x93, 0x89, 0xb2, 0xd3, 0xdb, 0x76, 0xc6, 0x25, 0x0b, 0x43, 0x2a, 0x16, 0xa0, 0x3e,
-	0xf5, 0xa1, 0xbc, 0xef, 0x69, 0xa2, 0x1a, 0xd3, 0x24, 0xe4, 0xc0, 0xc3, 0x78, 0x41, 0xa1, 0x39,
-	0x93, 0xcc, 0x9a, 0xb8, 0xc4, 0x1e, 0xa2, 0xfc, 0x16, 0xfe, 0x12, 0xff, 0x09, 0xc5, 0x75, 0x6e,
-	0x6d, 0x5a, 0x95, 0xbd, 0x39, 0x3e, 0xe7, 0xbb, 0x9c, 0xcf, 0x76, 0xa0, 0x1f, 0x93, 0x0e, 0xa3,
-	0x50, 0x87, 0xe3, 0x45, 0x2a, 0xb5, 0xc4, 0xc7, 0xf9, 0x37, 0xfb, 0xe3, 0x40, 0xf7, 0xbd, 0x98,
-	0xd3, 0xb5, 0xdd, 0xc0, 0x73, 0x68, 0xcf, 0x52, 0x0a, 0x35, 0x45, 0x5e, 0x6b, 0xd8, 0x1a, 0x75,
-	0x26, 0xaf, 0xc7, 0x05, 0xb8, 0xda, 0x38, 0xfe, 0x9c, 0x88, 0x5f, 0x9f, 0x44, 0x4c, 0x4a, 0x87,
-	0xf1, 0x82, 0xe7, 0x20, 0xbc, 0x84, 0xde, 0x3c, 0x54, 0xfa, 0x6b, 0x2c, 0x23, 0x71, 0x2b, 0x28,
-	0xf2, 0x9c, 0xff, 0x60, 0xe9, 0x66, 0xd0, 0x6b, 0x8b, 0xc4, 0x21, 0x74, 0x16, 0x94, 0xc6, 0x42,
-	0x29, 0x21, 0x13, 0xe5, 0xb9, 0xc3, 0xd6, 0xa8, 0xc7, 0xab, 0x5b, 0x88, 0x70, 0xa0, 0xc4, 0x6f,
-	0xf2, 0x0e, 0x86, 0xad, 0x91, 0xcb, 0xcd, 0xda, 0xbf, 0x82, 0x5e, 0x8d, 0x14, 0x3d, 0x68, 0x2b,
-	0x9a, 0xc9, 0x24, 0x52, 0x66, 0x22, 0x97, 0xe7, 0x9f, 0x99, 0x40, 0x12, 0x26, 0x32, 0xaf, 0x3a,
-	0xa6, 0x5a, 0xdd, 0x62, 0xa7, 0xf0, 0x7c, 0x4a, 0xfa, 0x42, 0xa4, 0x34, 0xd3, 0x32, 0x5d, 0x5e,
-	0xd1, 0x52, 0x71, 0xfa, 0x71, 0x4f, 0x4a, 0xb3, 0x31, 0x78, 0x9b, 0x25, 0xb5, 0x90, 0x89, 0xa2,
-	0xcc, 0xd7, 0x1d, 0x2d, 0x33, 0x3d, 0x77, 0x74, 0xc8, 0xcd, 0x9a, 0xbd, 0x05, 0x9c, 0x92, 0xce,
-	0x07, 0xb7, 0x2c, 0x78, 0x04, 0xee, 0x1d, 0x2d, 0x8d, 0xb1, 0x43, 0x9e, 0x2d, 0xd9, 0x25, 0x9c,
-	0xd4, 0xfa, 0x2c, 0xe5, 0x04, 0x8a, 0x43, 0xb3, 0x07, 0xf3, 0xac, 0x39, 0x52, 0x5e, 0x1e, 0xee,
-	0x17, 0xc0, 0x60, 0x0f, 0xc9, 0x1a, 0xb7, 0xb3, 0x27, 0xf7, 0x53, 0x38, 0x09, 0x36, 0x6d, 0x32,
-	0x06, 0xfd, 0x29, 0xe9, 0x0c, 0xb3, 0x7d, 0xc2, 0x1b, 0x18, 0x14, 0x3d, 0x65, 0x60, 0xb7, 0x62,
-	0x4e, 0xa6, 0xab, 0xcb, 0xcd, 0xfa, 0x41, 0xae, 0xbe, 0x43, 0xff, 0xe3, 0xfd, 0x6e, 0xf9, 0x42,
-	0xcb, 0xd9, 0xa2, 0xe5, 0xee, 0xa9, 0x75, 0x0c, 0x83, 0x42, 0xcb, 0x4e, 0xff, 0x06, 0x8e, 0x2f,
-	0x68, 0x4e, 0x9a, 0x76, 0x07, 0xf0, 0x04, 0xb0, 0xda, 0xb6, 0x02, 0x4f, 0xfe, 0xba, 0x30, 0xc8,
-	0x65, 0x02, 0x4a, 0x7f, 0x8a, 0x19, 0x65, 0xaf, 0xd1, 0x46, 0x85, 0x5e, 0x69, 0xa8, 0x9e, 0xb0,
-	0x7f, 0xda, 0x50, 0xb1, 0xb9, 0x9e, 0x43, 0xdb, 0x7a, 0xac, 0xe2, 0xeb, 0x11, 0x55, 0xf1, 0x6b,
-	0x03, 0xe1, 0x14, 0xa0, 0x74, 0x8a, 0x2f, 0xca, 0xc6, 0x8d, 0x31, 0xfd, 0xb3, 0xe6, 0xa2, 0x25,
-	0xfa, 0x00, 0x9d, 0xca, 0xad, 0xc6, 0xb3, 0x9a, 0xe5, 0xb5, 0x1b, 0xea, 0xbf, 0xdc, 0x52, 0x2d,
-	0xb9, 0x82, 0x66, 0xae, 0x60, 0x27, 0x57, 0xc3, 0x7d, 0xc5, 0x1b, 0x38, 0x5a, 0x7f, 0xc5, 0xf8,
-	0xaa, 0x26, 0xdf, 0xf4, 0xf8, 0x7d, 0xb6, 0xab, 0x65, 0x45, 0xfd, 0xed, 0x91, 0xf9, 0xd7, 0xbe,
-	0xfb, 0x17, 0x00, 0x00, 0xff, 0xff, 0x82, 0x12, 0xba, 0x3c, 0x7d, 0x05, 0x00, 0x00,
+var fileDescriptor_metadata_42681d185838b055 = []byte{
+	// 590 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x94, 0x55, 0xdd, 0x6e, 0xd3, 0x4c,
+	0x10, 0x95, 0x93, 0xf6, 0x4b, 0xbe, 0xc9, 0x9f, 0x3a, 0x85, 0xe2, 0xba, 0x45, 0x72, 0xa3, 0x22,
+	0x7c, 0x81, 0x22, 0x14, 0xb8, 0xe2, 0xa2, 0x37, 0x34, 0x44, 0x02, 0x15, 0x21, 0x87, 0x22, 0x2e,
+	0x90, 0x2a, 0x37, 0x9e, 0xaa, 0x2b, 0x25, 0x76, 0xf0, 0x6e, 0x11, 0xe5, 0x01, 0x78, 0x21, 0x24,
+	0x9e, 0x0f, 0xd9, 0x59, 0xdb, 0xeb, 0x9f, 0x38, 0xee, 0x9d, 0x77, 0x66, 0xce, 0x99, 0x9d, 0xd9,
+	0x73, 0x12, 0xe8, 0x2f, 0x49, 0x38, 0xae, 0x23, 0x9c, 0xd1, 0x2a, 0xf0, 0x85, 0x8f, 0xed, 0xf8,
+	0x3c, 0xfc, 0xd3, 0x80, 0xf6, 0x85, 0x3c, 0xe0, 0x1b, 0x68, 0xcd, 0x03, 0x72, 0x04, 0xb9, 0xba,
+	0x66, 0x6a, 0x56, 0x67, 0x6c, 0x8e, 0x12, 0x60, 0x5c, 0x34, 0xba, 0xf4, 0xd8, 0xcf, 0xcf, 0x6c,
+	0x49, 0x5c, 0x38, 0xcb, 0x95, 0x1d, 0x03, 0x70, 0x02, 0xbd, 0x85, 0xc3, 0xc5, 0xd5, 0xd2, 0x77,
+	0xd9, 0x0d, 0x23, 0x57, 0x6f, 0xd4, 0x64, 0xe8, 0x86, 0xb0, 0x0b, 0x89, 0x42, 0x13, 0x3a, 0x2b,
+	0x0a, 0x96, 0x8c, 0x73, 0xe6, 0x7b, 0x5c, 0x6f, 0x9a, 0x9a, 0xd5, 0xb3, 0xd5, 0x10, 0x22, 0xec,
+	0x70, 0xf6, 0x8b, 0xf4, 0x1d, 0x53, 0xb3, 0x9a, 0x76, 0xf4, 0x8d, 0x27, 0xd0, 0x65, 0xfc, 0xca,
+	0x65, 0x01, 0xcd, 0x85, 0x1f, 0xdc, 0xeb, 0xbb, 0xa6, 0x66, 0xb5, 0xed, 0x0e, 0xe3, 0xe7, 0x71,
+	0xc8, 0xf8, 0x00, 0xbd, 0x4c, 0x5f, 0xd4, 0xa1, 0xc5, 0x69, 0xee, 0x7b, 0x2e, 0x8f, 0x86, 0x6d,
+	0xda, 0xf1, 0x31, 0xbc, 0x83, 0xe7, 0x78, 0x7e, 0x9c, 0x6d, 0x44, 0x59, 0x35, 0x34, 0x3c, 0x85,
+	0xfe, 0x94, 0xc4, 0x3b, 0xb6, 0x20, 0x9b, 0xbe, 0xdf, 0x11, 0x17, 0xe1, 0xad, 0x56, 0x8e, 0xb8,
+	0x8d, 0xa8, 0xfe, 0xb7, 0xa3, 0xef, 0xe1, 0x25, 0x0c, 0x92, 0x2a, 0xbe, 0xf2, 0x3d, 0x4e, 0x61,
+	0xd9, 0x0d, 0x5b, 0x50, 0x54, 0xd6, 0xb5, 0xa3, 0x6f, 0x1c, 0x41, 0xf2, 0x1c, 0x72, 0x69, 0x58,
+	0x5c, 0x9a, 0x9d, 0x3e, 0xd9, 0x2d, 0xf4, 0x3f, 0xdd, 0x6d, 0x6b, 0x9e, 0x74, 0x6a, 0x6c, 0xe8,
+	0xd4, 0xac, 0xd1, 0x69, 0x0f, 0x06, 0x49, 0xa7, 0xf5, 0x00, 0xc3, 0xe7, 0xb0, 0x77, 0x4e, 0x0b,
+	0x12, 0xb4, 0x6d, 0xf8, 0x47, 0x80, 0x6a, 0xa1, 0x84, 0xbf, 0x04, 0x63, 0x4a, 0x22, 0x79, 0x95,
+	0x89, 0x27, 0x02, 0x46, 0xbc, 0x8a, 0xe7, 0xaf, 0x06, 0x47, 0xa5, 0x10, 0xb9, 0xd1, 0x8f, 0xd0,
+	0xa2, 0x75, 0x48, 0xd7, 0xcc, 0xa6, 0xd5, 0x19, 0xbf, 0x4e, 0x47, 0xaa, 0xc0, 0x8d, 0x32, 0x89,
+	0x7b, 0x3b, 0x26, 0x31, 0xa6, 0xd0, 0xcf, 0xa6, 0x4a, 0xb7, 0x9b, 0x17, 0x5c, 0xa3, 0x20, 0xb8,
+	0xe1, 0x37, 0x38, 0x78, 0x1b, 0x79, 0x23, 0x09, 0x55, 0x3d, 0xd7, 0x43, 0x45, 0x70, 0x08, 0x4f,
+	0x0a, 0xec, 0x72, 0xc7, 0x2f, 0xe0, 0x60, 0xbd, 0xf9, 0x3a, 0x8d, 0x43, 0xa2, 0x42, 0xb5, 0x24,
+	0xb2, 0x00, 0xa7, 0x24, 0x92, 0xe6, 0x15, 0x24, 0x13, 0xd8, 0xcf, 0x54, 0xca, 0xb7, 0x51, 0x87,
+	0xd2, 0x6a, 0x0c, 0xf5, 0x15, 0x70, 0x56, 0xab, 0xe1, 0x83, 0xd7, 0xf5, 0x18, 0xf6, 0x67, 0xc5,
+	0x0b, 0x8e, 0x7f, 0xef, 0xc2, 0x20, 0x0e, 0xce, 0x28, 0xf8, 0xc1, 0xe6, 0x84, 0x67, 0xd0, 0x92,
+	0xae, 0x45, 0x3d, 0x23, 0x25, 0x45, 0xf1, 0xc6, 0x61, 0x49, 0x46, 0x0e, 0x7d, 0x06, 0x2d, 0x69,
+	0x1a, 0x15, 0x9f, 0x75, 0xac, 0x8a, 0xcf, 0x39, 0x0c, 0xa7, 0x00, 0xa9, 0x71, 0xf0, 0x28, 0x2d,
+	0x2c, 0xf8, 0xce, 0x38, 0x2e, 0x4f, 0x4a, 0xa2, 0x2f, 0x30, 0xc8, 0x49, 0x04, 0x95, 0x5f, 0xe3,
+	0x72, 0x6d, 0x1a, 0x27, 0x15, 0x15, 0x29, 0x6f, 0x4e, 0x31, 0x2a, 0x6f, 0xb9, 0xf4, 0x54, 0xde,
+	0x0d, 0x72, 0xc3, 0xeb, 0x48, 0x44, 0x79, 0xc3, 0xe2, 0xe9, 0x16, 0x3f, 0xaf, 0xf9, 0x9f, 0xd5,
+	0x72, 0x3d, 0xbe, 0x87, 0x8e, 0x22, 0x54, 0x3c, 0xce, 0xa0, 0x72, 0xc2, 0x33, 0x9e, 0x6e, 0xc8,
+	0xa6, 0x5c, 0xb3, 0x72, 0xae, 0x59, 0x25, 0x57, 0x89, 0x10, 0xaf, 0xff, 0x8b, 0xfe, 0x97, 0x5f,
+	0xfd, 0x0b, 0x00, 0x00, 0xff, 0xff, 0x23, 0x55, 0x17, 0x91, 0xa9, 0x07, 0x00, 0x00,
 }

--- a/pkg/pb/metadata/metadata.proto
+++ b/pkg/pb/metadata/metadata.proto
@@ -18,7 +18,7 @@ package metadata;
 
 // TODO (Franz): This should be encrypted; move this to the encryption
 // server when its implemented
-message FileMetadata {
+message Metadata {
     message UnixTimestamp {
         int64 seconds = 1;
         int64 nanoseconds = 2;
@@ -27,57 +27,82 @@ message FileMetadata {
     UnixTimestamp last_modified = 2;
     uint32 permissions = 3;
     int64 size = 4;
+    bool is_directory = 5;
 }
-
-message GetDirectoryKeysRequest {}
-
-message GetDirectoryKeysResponse {
-    repeated string keys = 1;
-}
-
-message GetMetadataRequest {
-    string key = 1;
-}
-
-message GetMetadataResponse {
-    FileMetadata metadata = 1;
-}
-
-message SetMetadataRequest {
-    string key = 1;
-    FileMetadata metadata = 2;
-}
-
-message SetMetadataResponse { }
 
 message GetFileRequest {
-    string key = 1;
+  string path = 1;
 }
 
 message GetFileResponse {
-    bytes file = 1;
-    FileMetadata metadata = 2;
+  bytes file = 1;
+  Metadata metadata = 2;
 }
 
 message PutFileRequest {
-    string key = 1;
-    bytes file = 2;
-    FileMetadata metadata = 3;
+  string path = 1;
+  bytes file = 2;
+  Metadata metadata = 3;
 }
 
 message PutFileResponse { }
 
 message DeleteFileRequest {
-    string key = 1;
+  string path = 1;
 }
 
 message DeleteFileResponse { }
+
+message GetDirectoryEntriesRequest {
+  string path = 1;
+}
+
+message GetDirectoryEntriesResponse {
+  message DirectoryEntry {
+    string path = 1;
+    bool is_directory = 2;
+  }
+  repeated DirectoryEntry entries = 1;
+}
+
+message CreateDirectoryRequest {
+  string path = 1;
+  Metadata metadata = 2;
+}
+
+message CreateDirectoryResponse { }
+
+message DeleteDirectoryRequest {
+  string path = 1;
+}
+
+message DeleteDirectoryResponse { }
+
+message GetMetadataRequest {
+  string path = 1;
+}
+
+message GetMetadataResponse {
+  Metadata metadata = 1;
+}
+
+message SetMetadataRequest {
+  string path = 1;
+  Metadata metadata = 2;
+}
+
+message SetMetadataResponse { }
+
+// TODO: Create RPC to copy folder recursively.
 
 service MetadataService { 
     rpc GetFile (GetFileRequest) returns (GetFileResponse);
     rpc PutFile (PutFileRequest) returns (PutFileResponse);
     rpc DeleteFile (DeleteFileRequest) returns (DeleteFileResponse);
+    rpc CreateDirectory (CreateDirectoryRequest) returns (CreateDirectoryResponse);
+    rpc DeleteDirectory (DeleteDirectoryRequest) returns (DeleteDirectoryResponse);
+    rpc GetDirectoryEntries (GetDirectoryEntriesRequest) returns (GetDirectoryEntriesResponse);
+
     rpc GetMetadata (GetMetadataRequest) returns (GetMetadataResponse);
     rpc SetMetadata (SetMetadataRequest) returns (SetMetadataResponse);
-    rpc GetDirectoryKeys (GetDirectoryKeysRequest) returns (GetDirectoryKeysResponse);
 }

--- a/pkg/pb/storage/storage.pb.go
+++ b/pkg/pb/storage/storage.pb.go
@@ -23,288 +23,288 @@ var _ = math.Inf
 // proto package needs to be updated.
 const _ = proto.ProtoPackageIsVersion2 // please upgrade the proto package
 
-type GetFileRequest struct {
+type GetBlobRequest struct {
 	Key                  string   `protobuf:"bytes,1,opt,name=key,proto3" json:"key,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
 }
 
-func (m *GetFileRequest) Reset()         { *m = GetFileRequest{} }
-func (m *GetFileRequest) String() string { return proto.CompactTextString(m) }
-func (*GetFileRequest) ProtoMessage()    {}
-func (*GetFileRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_storage_67770c3923954988, []int{0}
+func (m *GetBlobRequest) Reset()         { *m = GetBlobRequest{} }
+func (m *GetBlobRequest) String() string { return proto.CompactTextString(m) }
+func (*GetBlobRequest) ProtoMessage()    {}
+func (*GetBlobRequest) Descriptor() ([]byte, []int) {
+	return fileDescriptor_storage_761b0d99bd4e86bf, []int{0}
 }
-func (m *GetFileRequest) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_GetFileRequest.Unmarshal(m, b)
+func (m *GetBlobRequest) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_GetBlobRequest.Unmarshal(m, b)
 }
-func (m *GetFileRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_GetFileRequest.Marshal(b, m, deterministic)
+func (m *GetBlobRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_GetBlobRequest.Marshal(b, m, deterministic)
 }
-func (dst *GetFileRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_GetFileRequest.Merge(dst, src)
+func (dst *GetBlobRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_GetBlobRequest.Merge(dst, src)
 }
-func (m *GetFileRequest) XXX_Size() int {
-	return xxx_messageInfo_GetFileRequest.Size(m)
+func (m *GetBlobRequest) XXX_Size() int {
+	return xxx_messageInfo_GetBlobRequest.Size(m)
 }
-func (m *GetFileRequest) XXX_DiscardUnknown() {
-	xxx_messageInfo_GetFileRequest.DiscardUnknown(m)
+func (m *GetBlobRequest) XXX_DiscardUnknown() {
+	xxx_messageInfo_GetBlobRequest.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_GetFileRequest proto.InternalMessageInfo
+var xxx_messageInfo_GetBlobRequest proto.InternalMessageInfo
 
-func (m *GetFileRequest) GetKey() string {
+func (m *GetBlobRequest) GetKey() string {
 	if m != nil {
 		return m.Key
 	}
 	return ""
 }
 
-type GetFileResponse struct {
-	File                 []byte   `protobuf:"bytes,1,opt,name=file,proto3" json:"file,omitempty"`
+type GetBlobResponse struct {
+	Data                 []byte   `protobuf:"bytes,1,opt,name=data,proto3" json:"data,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
 }
 
-func (m *GetFileResponse) Reset()         { *m = GetFileResponse{} }
-func (m *GetFileResponse) String() string { return proto.CompactTextString(m) }
-func (*GetFileResponse) ProtoMessage()    {}
-func (*GetFileResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_storage_67770c3923954988, []int{1}
+func (m *GetBlobResponse) Reset()         { *m = GetBlobResponse{} }
+func (m *GetBlobResponse) String() string { return proto.CompactTextString(m) }
+func (*GetBlobResponse) ProtoMessage()    {}
+func (*GetBlobResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_storage_761b0d99bd4e86bf, []int{1}
 }
-func (m *GetFileResponse) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_GetFileResponse.Unmarshal(m, b)
+func (m *GetBlobResponse) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_GetBlobResponse.Unmarshal(m, b)
 }
-func (m *GetFileResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_GetFileResponse.Marshal(b, m, deterministic)
+func (m *GetBlobResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_GetBlobResponse.Marshal(b, m, deterministic)
 }
-func (dst *GetFileResponse) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_GetFileResponse.Merge(dst, src)
+func (dst *GetBlobResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_GetBlobResponse.Merge(dst, src)
 }
-func (m *GetFileResponse) XXX_Size() int {
-	return xxx_messageInfo_GetFileResponse.Size(m)
+func (m *GetBlobResponse) XXX_Size() int {
+	return xxx_messageInfo_GetBlobResponse.Size(m)
 }
-func (m *GetFileResponse) XXX_DiscardUnknown() {
-	xxx_messageInfo_GetFileResponse.DiscardUnknown(m)
+func (m *GetBlobResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_GetBlobResponse.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_GetFileResponse proto.InternalMessageInfo
+var xxx_messageInfo_GetBlobResponse proto.InternalMessageInfo
 
-func (m *GetFileResponse) GetFile() []byte {
+func (m *GetBlobResponse) GetData() []byte {
 	if m != nil {
-		return m.File
+		return m.Data
 	}
 	return nil
 }
 
-type PutFileRequest struct {
+type PutBlobRequest struct {
 	Key                  string   `protobuf:"bytes,1,opt,name=key,proto3" json:"key,omitempty"`
-	File                 []byte   `protobuf:"bytes,2,opt,name=file,proto3" json:"file,omitempty"`
+	Data                 []byte   `protobuf:"bytes,2,opt,name=data,proto3" json:"data,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
 }
 
-func (m *PutFileRequest) Reset()         { *m = PutFileRequest{} }
-func (m *PutFileRequest) String() string { return proto.CompactTextString(m) }
-func (*PutFileRequest) ProtoMessage()    {}
-func (*PutFileRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_storage_67770c3923954988, []int{2}
+func (m *PutBlobRequest) Reset()         { *m = PutBlobRequest{} }
+func (m *PutBlobRequest) String() string { return proto.CompactTextString(m) }
+func (*PutBlobRequest) ProtoMessage()    {}
+func (*PutBlobRequest) Descriptor() ([]byte, []int) {
+	return fileDescriptor_storage_761b0d99bd4e86bf, []int{2}
 }
-func (m *PutFileRequest) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_PutFileRequest.Unmarshal(m, b)
+func (m *PutBlobRequest) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_PutBlobRequest.Unmarshal(m, b)
 }
-func (m *PutFileRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_PutFileRequest.Marshal(b, m, deterministic)
+func (m *PutBlobRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_PutBlobRequest.Marshal(b, m, deterministic)
 }
-func (dst *PutFileRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_PutFileRequest.Merge(dst, src)
+func (dst *PutBlobRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_PutBlobRequest.Merge(dst, src)
 }
-func (m *PutFileRequest) XXX_Size() int {
-	return xxx_messageInfo_PutFileRequest.Size(m)
+func (m *PutBlobRequest) XXX_Size() int {
+	return xxx_messageInfo_PutBlobRequest.Size(m)
 }
-func (m *PutFileRequest) XXX_DiscardUnknown() {
-	xxx_messageInfo_PutFileRequest.DiscardUnknown(m)
+func (m *PutBlobRequest) XXX_DiscardUnknown() {
+	xxx_messageInfo_PutBlobRequest.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_PutFileRequest proto.InternalMessageInfo
+var xxx_messageInfo_PutBlobRequest proto.InternalMessageInfo
 
-func (m *PutFileRequest) GetKey() string {
+func (m *PutBlobRequest) GetKey() string {
 	if m != nil {
 		return m.Key
 	}
 	return ""
 }
 
-func (m *PutFileRequest) GetFile() []byte {
+func (m *PutBlobRequest) GetData() []byte {
 	if m != nil {
-		return m.File
+		return m.Data
 	}
 	return nil
 }
 
-type PutFileResponse struct {
+type PutBlobResponse struct {
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
 }
 
-func (m *PutFileResponse) Reset()         { *m = PutFileResponse{} }
-func (m *PutFileResponse) String() string { return proto.CompactTextString(m) }
-func (*PutFileResponse) ProtoMessage()    {}
-func (*PutFileResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_storage_67770c3923954988, []int{3}
+func (m *PutBlobResponse) Reset()         { *m = PutBlobResponse{} }
+func (m *PutBlobResponse) String() string { return proto.CompactTextString(m) }
+func (*PutBlobResponse) ProtoMessage()    {}
+func (*PutBlobResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_storage_761b0d99bd4e86bf, []int{3}
 }
-func (m *PutFileResponse) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_PutFileResponse.Unmarshal(m, b)
+func (m *PutBlobResponse) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_PutBlobResponse.Unmarshal(m, b)
 }
-func (m *PutFileResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_PutFileResponse.Marshal(b, m, deterministic)
+func (m *PutBlobResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_PutBlobResponse.Marshal(b, m, deterministic)
 }
-func (dst *PutFileResponse) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_PutFileResponse.Merge(dst, src)
+func (dst *PutBlobResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_PutBlobResponse.Merge(dst, src)
 }
-func (m *PutFileResponse) XXX_Size() int {
-	return xxx_messageInfo_PutFileResponse.Size(m)
+func (m *PutBlobResponse) XXX_Size() int {
+	return xxx_messageInfo_PutBlobResponse.Size(m)
 }
-func (m *PutFileResponse) XXX_DiscardUnknown() {
-	xxx_messageInfo_PutFileResponse.DiscardUnknown(m)
+func (m *PutBlobResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_PutBlobResponse.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_PutFileResponse proto.InternalMessageInfo
+var xxx_messageInfo_PutBlobResponse proto.InternalMessageInfo
 
-type DeleteFileRequest struct {
+type DeleteBlobRequest struct {
 	Key                  string   `protobuf:"bytes,1,opt,name=key,proto3" json:"key,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
 }
 
-func (m *DeleteFileRequest) Reset()         { *m = DeleteFileRequest{} }
-func (m *DeleteFileRequest) String() string { return proto.CompactTextString(m) }
-func (*DeleteFileRequest) ProtoMessage()    {}
-func (*DeleteFileRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_storage_67770c3923954988, []int{4}
+func (m *DeleteBlobRequest) Reset()         { *m = DeleteBlobRequest{} }
+func (m *DeleteBlobRequest) String() string { return proto.CompactTextString(m) }
+func (*DeleteBlobRequest) ProtoMessage()    {}
+func (*DeleteBlobRequest) Descriptor() ([]byte, []int) {
+	return fileDescriptor_storage_761b0d99bd4e86bf, []int{4}
 }
-func (m *DeleteFileRequest) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_DeleteFileRequest.Unmarshal(m, b)
+func (m *DeleteBlobRequest) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_DeleteBlobRequest.Unmarshal(m, b)
 }
-func (m *DeleteFileRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_DeleteFileRequest.Marshal(b, m, deterministic)
+func (m *DeleteBlobRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_DeleteBlobRequest.Marshal(b, m, deterministic)
 }
-func (dst *DeleteFileRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_DeleteFileRequest.Merge(dst, src)
+func (dst *DeleteBlobRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_DeleteBlobRequest.Merge(dst, src)
 }
-func (m *DeleteFileRequest) XXX_Size() int {
-	return xxx_messageInfo_DeleteFileRequest.Size(m)
+func (m *DeleteBlobRequest) XXX_Size() int {
+	return xxx_messageInfo_DeleteBlobRequest.Size(m)
 }
-func (m *DeleteFileRequest) XXX_DiscardUnknown() {
-	xxx_messageInfo_DeleteFileRequest.DiscardUnknown(m)
+func (m *DeleteBlobRequest) XXX_DiscardUnknown() {
+	xxx_messageInfo_DeleteBlobRequest.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_DeleteFileRequest proto.InternalMessageInfo
+var xxx_messageInfo_DeleteBlobRequest proto.InternalMessageInfo
 
-func (m *DeleteFileRequest) GetKey() string {
+func (m *DeleteBlobRequest) GetKey() string {
 	if m != nil {
 		return m.Key
 	}
 	return ""
 }
 
-type DeleteFileResponse struct {
+type DeleteBlobResponse struct {
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
 }
 
-func (m *DeleteFileResponse) Reset()         { *m = DeleteFileResponse{} }
-func (m *DeleteFileResponse) String() string { return proto.CompactTextString(m) }
-func (*DeleteFileResponse) ProtoMessage()    {}
-func (*DeleteFileResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_storage_67770c3923954988, []int{5}
+func (m *DeleteBlobResponse) Reset()         { *m = DeleteBlobResponse{} }
+func (m *DeleteBlobResponse) String() string { return proto.CompactTextString(m) }
+func (*DeleteBlobResponse) ProtoMessage()    {}
+func (*DeleteBlobResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_storage_761b0d99bd4e86bf, []int{5}
 }
-func (m *DeleteFileResponse) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_DeleteFileResponse.Unmarshal(m, b)
+func (m *DeleteBlobResponse) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_DeleteBlobResponse.Unmarshal(m, b)
 }
-func (m *DeleteFileResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_DeleteFileResponse.Marshal(b, m, deterministic)
+func (m *DeleteBlobResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_DeleteBlobResponse.Marshal(b, m, deterministic)
 }
-func (dst *DeleteFileResponse) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_DeleteFileResponse.Merge(dst, src)
+func (dst *DeleteBlobResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_DeleteBlobResponse.Merge(dst, src)
 }
-func (m *DeleteFileResponse) XXX_Size() int {
-	return xxx_messageInfo_DeleteFileResponse.Size(m)
+func (m *DeleteBlobResponse) XXX_Size() int {
+	return xxx_messageInfo_DeleteBlobResponse.Size(m)
 }
-func (m *DeleteFileResponse) XXX_DiscardUnknown() {
-	xxx_messageInfo_DeleteFileResponse.DiscardUnknown(m)
+func (m *DeleteBlobResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_DeleteBlobResponse.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_DeleteFileResponse proto.InternalMessageInfo
+var xxx_messageInfo_DeleteBlobResponse proto.InternalMessageInfo
 
-type GetFileKeysRequest struct {
+type GetBlobKeysRequest struct {
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
 }
 
-func (m *GetFileKeysRequest) Reset()         { *m = GetFileKeysRequest{} }
-func (m *GetFileKeysRequest) String() string { return proto.CompactTextString(m) }
-func (*GetFileKeysRequest) ProtoMessage()    {}
-func (*GetFileKeysRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_storage_67770c3923954988, []int{6}
+func (m *GetBlobKeysRequest) Reset()         { *m = GetBlobKeysRequest{} }
+func (m *GetBlobKeysRequest) String() string { return proto.CompactTextString(m) }
+func (*GetBlobKeysRequest) ProtoMessage()    {}
+func (*GetBlobKeysRequest) Descriptor() ([]byte, []int) {
+	return fileDescriptor_storage_761b0d99bd4e86bf, []int{6}
 }
-func (m *GetFileKeysRequest) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_GetFileKeysRequest.Unmarshal(m, b)
+func (m *GetBlobKeysRequest) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_GetBlobKeysRequest.Unmarshal(m, b)
 }
-func (m *GetFileKeysRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_GetFileKeysRequest.Marshal(b, m, deterministic)
+func (m *GetBlobKeysRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_GetBlobKeysRequest.Marshal(b, m, deterministic)
 }
-func (dst *GetFileKeysRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_GetFileKeysRequest.Merge(dst, src)
+func (dst *GetBlobKeysRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_GetBlobKeysRequest.Merge(dst, src)
 }
-func (m *GetFileKeysRequest) XXX_Size() int {
-	return xxx_messageInfo_GetFileKeysRequest.Size(m)
+func (m *GetBlobKeysRequest) XXX_Size() int {
+	return xxx_messageInfo_GetBlobKeysRequest.Size(m)
 }
-func (m *GetFileKeysRequest) XXX_DiscardUnknown() {
-	xxx_messageInfo_GetFileKeysRequest.DiscardUnknown(m)
+func (m *GetBlobKeysRequest) XXX_DiscardUnknown() {
+	xxx_messageInfo_GetBlobKeysRequest.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_GetFileKeysRequest proto.InternalMessageInfo
+var xxx_messageInfo_GetBlobKeysRequest proto.InternalMessageInfo
 
-type GetFileKeysResponse struct {
+type GetBlobKeysResponse struct {
 	Keys                 []string `protobuf:"bytes,1,rep,name=keys,proto3" json:"keys,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
 }
 
-func (m *GetFileKeysResponse) Reset()         { *m = GetFileKeysResponse{} }
-func (m *GetFileKeysResponse) String() string { return proto.CompactTextString(m) }
-func (*GetFileKeysResponse) ProtoMessage()    {}
-func (*GetFileKeysResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_storage_67770c3923954988, []int{7}
+func (m *GetBlobKeysResponse) Reset()         { *m = GetBlobKeysResponse{} }
+func (m *GetBlobKeysResponse) String() string { return proto.CompactTextString(m) }
+func (*GetBlobKeysResponse) ProtoMessage()    {}
+func (*GetBlobKeysResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_storage_761b0d99bd4e86bf, []int{7}
 }
-func (m *GetFileKeysResponse) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_GetFileKeysResponse.Unmarshal(m, b)
+func (m *GetBlobKeysResponse) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_GetBlobKeysResponse.Unmarshal(m, b)
 }
-func (m *GetFileKeysResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_GetFileKeysResponse.Marshal(b, m, deterministic)
+func (m *GetBlobKeysResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_GetBlobKeysResponse.Marshal(b, m, deterministic)
 }
-func (dst *GetFileKeysResponse) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_GetFileKeysResponse.Merge(dst, src)
+func (dst *GetBlobKeysResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_GetBlobKeysResponse.Merge(dst, src)
 }
-func (m *GetFileKeysResponse) XXX_Size() int {
-	return xxx_messageInfo_GetFileKeysResponse.Size(m)
+func (m *GetBlobKeysResponse) XXX_Size() int {
+	return xxx_messageInfo_GetBlobKeysResponse.Size(m)
 }
-func (m *GetFileKeysResponse) XXX_DiscardUnknown() {
-	xxx_messageInfo_GetFileKeysResponse.DiscardUnknown(m)
+func (m *GetBlobKeysResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_GetBlobKeysResponse.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_GetFileKeysResponse proto.InternalMessageInfo
+var xxx_messageInfo_GetBlobKeysResponse proto.InternalMessageInfo
 
-func (m *GetFileKeysResponse) GetKeys() []string {
+func (m *GetBlobKeysResponse) GetKeys() []string {
 	if m != nil {
 		return m.Keys
 	}
@@ -312,14 +312,14 @@ func (m *GetFileKeysResponse) GetKeys() []string {
 }
 
 func init() {
-	proto.RegisterType((*GetFileRequest)(nil), "storage.GetFileRequest")
-	proto.RegisterType((*GetFileResponse)(nil), "storage.GetFileResponse")
-	proto.RegisterType((*PutFileRequest)(nil), "storage.PutFileRequest")
-	proto.RegisterType((*PutFileResponse)(nil), "storage.PutFileResponse")
-	proto.RegisterType((*DeleteFileRequest)(nil), "storage.DeleteFileRequest")
-	proto.RegisterType((*DeleteFileResponse)(nil), "storage.DeleteFileResponse")
-	proto.RegisterType((*GetFileKeysRequest)(nil), "storage.GetFileKeysRequest")
-	proto.RegisterType((*GetFileKeysResponse)(nil), "storage.GetFileKeysResponse")
+	proto.RegisterType((*GetBlobRequest)(nil), "storage.GetBlobRequest")
+	proto.RegisterType((*GetBlobResponse)(nil), "storage.GetBlobResponse")
+	proto.RegisterType((*PutBlobRequest)(nil), "storage.PutBlobRequest")
+	proto.RegisterType((*PutBlobResponse)(nil), "storage.PutBlobResponse")
+	proto.RegisterType((*DeleteBlobRequest)(nil), "storage.DeleteBlobRequest")
+	proto.RegisterType((*DeleteBlobResponse)(nil), "storage.DeleteBlobResponse")
+	proto.RegisterType((*GetBlobKeysRequest)(nil), "storage.GetBlobKeysRequest")
+	proto.RegisterType((*GetBlobKeysResponse)(nil), "storage.GetBlobKeysResponse")
 }
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -334,10 +334,10 @@ const _ = grpc.SupportPackageIsVersion4
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://godoc.org/google.golang.org/grpc#ClientConn.NewStream.
 type StorageServiceClient interface {
-	GetFile(ctx context.Context, in *GetFileRequest, opts ...grpc.CallOption) (*GetFileResponse, error)
-	PutFile(ctx context.Context, in *PutFileRequest, opts ...grpc.CallOption) (*PutFileResponse, error)
-	DeleteFile(ctx context.Context, in *DeleteFileRequest, opts ...grpc.CallOption) (*DeleteFileResponse, error)
-	GetFileKeys(ctx context.Context, in *GetFileKeysRequest, opts ...grpc.CallOption) (*GetFileKeysResponse, error)
+	GetBlob(ctx context.Context, in *GetBlobRequest, opts ...grpc.CallOption) (*GetBlobResponse, error)
+	PutBlob(ctx context.Context, in *PutBlobRequest, opts ...grpc.CallOption) (*PutBlobResponse, error)
+	DeleteBlob(ctx context.Context, in *DeleteBlobRequest, opts ...grpc.CallOption) (*DeleteBlobResponse, error)
+	GetBlobKeys(ctx context.Context, in *GetBlobKeysRequest, opts ...grpc.CallOption) (*GetBlobKeysResponse, error)
 }
 
 type storageServiceClient struct {
@@ -348,36 +348,36 @@ func NewStorageServiceClient(cc *grpc.ClientConn) StorageServiceClient {
 	return &storageServiceClient{cc}
 }
 
-func (c *storageServiceClient) GetFile(ctx context.Context, in *GetFileRequest, opts ...grpc.CallOption) (*GetFileResponse, error) {
-	out := new(GetFileResponse)
-	err := c.cc.Invoke(ctx, "/storage.StorageService/GetFile", in, out, opts...)
+func (c *storageServiceClient) GetBlob(ctx context.Context, in *GetBlobRequest, opts ...grpc.CallOption) (*GetBlobResponse, error) {
+	out := new(GetBlobResponse)
+	err := c.cc.Invoke(ctx, "/storage.StorageService/GetBlob", in, out, opts...)
 	if err != nil {
 		return nil, err
 	}
 	return out, nil
 }
 
-func (c *storageServiceClient) PutFile(ctx context.Context, in *PutFileRequest, opts ...grpc.CallOption) (*PutFileResponse, error) {
-	out := new(PutFileResponse)
-	err := c.cc.Invoke(ctx, "/storage.StorageService/PutFile", in, out, opts...)
+func (c *storageServiceClient) PutBlob(ctx context.Context, in *PutBlobRequest, opts ...grpc.CallOption) (*PutBlobResponse, error) {
+	out := new(PutBlobResponse)
+	err := c.cc.Invoke(ctx, "/storage.StorageService/PutBlob", in, out, opts...)
 	if err != nil {
 		return nil, err
 	}
 	return out, nil
 }
 
-func (c *storageServiceClient) DeleteFile(ctx context.Context, in *DeleteFileRequest, opts ...grpc.CallOption) (*DeleteFileResponse, error) {
-	out := new(DeleteFileResponse)
-	err := c.cc.Invoke(ctx, "/storage.StorageService/DeleteFile", in, out, opts...)
+func (c *storageServiceClient) DeleteBlob(ctx context.Context, in *DeleteBlobRequest, opts ...grpc.CallOption) (*DeleteBlobResponse, error) {
+	out := new(DeleteBlobResponse)
+	err := c.cc.Invoke(ctx, "/storage.StorageService/DeleteBlob", in, out, opts...)
 	if err != nil {
 		return nil, err
 	}
 	return out, nil
 }
 
-func (c *storageServiceClient) GetFileKeys(ctx context.Context, in *GetFileKeysRequest, opts ...grpc.CallOption) (*GetFileKeysResponse, error) {
-	out := new(GetFileKeysResponse)
-	err := c.cc.Invoke(ctx, "/storage.StorageService/GetFileKeys", in, out, opts...)
+func (c *storageServiceClient) GetBlobKeys(ctx context.Context, in *GetBlobKeysRequest, opts ...grpc.CallOption) (*GetBlobKeysResponse, error) {
+	out := new(GetBlobKeysResponse)
+	err := c.cc.Invoke(ctx, "/storage.StorageService/GetBlobKeys", in, out, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -386,84 +386,84 @@ func (c *storageServiceClient) GetFileKeys(ctx context.Context, in *GetFileKeysR
 
 // StorageServiceServer is the server API for StorageService service.
 type StorageServiceServer interface {
-	GetFile(context.Context, *GetFileRequest) (*GetFileResponse, error)
-	PutFile(context.Context, *PutFileRequest) (*PutFileResponse, error)
-	DeleteFile(context.Context, *DeleteFileRequest) (*DeleteFileResponse, error)
-	GetFileKeys(context.Context, *GetFileKeysRequest) (*GetFileKeysResponse, error)
+	GetBlob(context.Context, *GetBlobRequest) (*GetBlobResponse, error)
+	PutBlob(context.Context, *PutBlobRequest) (*PutBlobResponse, error)
+	DeleteBlob(context.Context, *DeleteBlobRequest) (*DeleteBlobResponse, error)
+	GetBlobKeys(context.Context, *GetBlobKeysRequest) (*GetBlobKeysResponse, error)
 }
 
 func RegisterStorageServiceServer(s *grpc.Server, srv StorageServiceServer) {
 	s.RegisterService(&_StorageService_serviceDesc, srv)
 }
 
-func _StorageService_GetFile_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(GetFileRequest)
+func _StorageService_GetBlob_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(GetBlobRequest)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(StorageServiceServer).GetFile(ctx, in)
+		return srv.(StorageServiceServer).GetBlob(ctx, in)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: "/storage.StorageService/GetFile",
+		FullMethod: "/storage.StorageService/GetBlob",
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(StorageServiceServer).GetFile(ctx, req.(*GetFileRequest))
+		return srv.(StorageServiceServer).GetBlob(ctx, req.(*GetBlobRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
-func _StorageService_PutFile_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(PutFileRequest)
+func _StorageService_PutBlob_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(PutBlobRequest)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(StorageServiceServer).PutFile(ctx, in)
+		return srv.(StorageServiceServer).PutBlob(ctx, in)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: "/storage.StorageService/PutFile",
+		FullMethod: "/storage.StorageService/PutBlob",
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(StorageServiceServer).PutFile(ctx, req.(*PutFileRequest))
+		return srv.(StorageServiceServer).PutBlob(ctx, req.(*PutBlobRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
-func _StorageService_DeleteFile_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(DeleteFileRequest)
+func _StorageService_DeleteBlob_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(DeleteBlobRequest)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(StorageServiceServer).DeleteFile(ctx, in)
+		return srv.(StorageServiceServer).DeleteBlob(ctx, in)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: "/storage.StorageService/DeleteFile",
+		FullMethod: "/storage.StorageService/DeleteBlob",
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(StorageServiceServer).DeleteFile(ctx, req.(*DeleteFileRequest))
+		return srv.(StorageServiceServer).DeleteBlob(ctx, req.(*DeleteBlobRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
-func _StorageService_GetFileKeys_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(GetFileKeysRequest)
+func _StorageService_GetBlobKeys_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(GetBlobKeysRequest)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(StorageServiceServer).GetFileKeys(ctx, in)
+		return srv.(StorageServiceServer).GetBlobKeys(ctx, in)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: "/storage.StorageService/GetFileKeys",
+		FullMethod: "/storage.StorageService/GetBlobKeys",
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(StorageServiceServer).GetFileKeys(ctx, req.(*GetFileKeysRequest))
+		return srv.(StorageServiceServer).GetBlobKeys(ctx, req.(*GetBlobKeysRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -473,45 +473,45 @@ var _StorageService_serviceDesc = grpc.ServiceDesc{
 	HandlerType: (*StorageServiceServer)(nil),
 	Methods: []grpc.MethodDesc{
 		{
-			MethodName: "GetFile",
-			Handler:    _StorageService_GetFile_Handler,
+			MethodName: "GetBlob",
+			Handler:    _StorageService_GetBlob_Handler,
 		},
 		{
-			MethodName: "PutFile",
-			Handler:    _StorageService_PutFile_Handler,
+			MethodName: "PutBlob",
+			Handler:    _StorageService_PutBlob_Handler,
 		},
 		{
-			MethodName: "DeleteFile",
-			Handler:    _StorageService_DeleteFile_Handler,
+			MethodName: "DeleteBlob",
+			Handler:    _StorageService_DeleteBlob_Handler,
 		},
 		{
-			MethodName: "GetFileKeys",
-			Handler:    _StorageService_GetFileKeys_Handler,
+			MethodName: "GetBlobKeys",
+			Handler:    _StorageService_GetBlobKeys_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},
 	Metadata: "storage.proto",
 }
 
-func init() { proto.RegisterFile("storage.proto", fileDescriptor_storage_67770c3923954988) }
+func init() { proto.RegisterFile("storage.proto", fileDescriptor_storage_761b0d99bd4e86bf) }
 
-var fileDescriptor_storage_67770c3923954988 = []byte{
-	// 266 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x7c, 0x92, 0xcf, 0x4a, 0xc3, 0x40,
-	0x10, 0xc6, 0x49, 0x2b, 0x86, 0x7e, 0x6a, 0x6a, 0xc7, 0x82, 0x21, 0xf5, 0x50, 0x16, 0x0a, 0xf5,
-	0xd2, 0x83, 0x82, 0xa7, 0x1e, 0xfd, 0x07, 0x5e, 0x24, 0x7d, 0x02, 0x95, 0x51, 0x42, 0x83, 0xa9,
-	0xd9, 0xad, 0x90, 0x87, 0xf1, 0x5d, 0xc5, 0xcd, 0xb8, 0xdd, 0xb4, 0x25, 0xb7, 0x49, 0x66, 0x7e,
-	0x5f, 0x66, 0x7e, 0x04, 0x27, 0xda, 0x14, 0xe5, 0xcb, 0x07, 0xcf, 0x56, 0x65, 0x61, 0x0a, 0x0a,
-	0xe5, 0x51, 0x29, 0x44, 0x0f, 0x6c, 0xee, 0xb3, 0x9c, 0x53, 0xfe, 0x5a, 0xb3, 0x36, 0x74, 0x8a,
-	0xee, 0x92, 0xab, 0x38, 0x18, 0x07, 0xd3, 0x5e, 0xfa, 0x57, 0xaa, 0x09, 0xfa, 0x6e, 0x46, 0xaf,
-	0x8a, 0x4f, 0xcd, 0x44, 0x38, 0x78, 0xcf, 0x72, 0xb6, 0x53, 0xc7, 0xa9, 0xad, 0xd5, 0x0d, 0xa2,
-	0xe7, 0x75, 0x7b, 0x94, 0xe3, 0x3a, 0x1e, 0x37, 0x40, 0xdf, 0x71, 0x75, 0xbc, 0x9a, 0x60, 0x70,
-	0xcb, 0x39, 0x1b, 0x6e, 0x5f, 0x6c, 0x08, 0xf2, 0xc7, 0x04, 0x1e, 0x82, 0x64, 0xdd, 0x27, 0xae,
-	0xb4, 0xd0, 0xea, 0x12, 0x67, 0x8d, 0xb7, 0x9b, 0x43, 0x96, 0x5c, 0xe9, 0x38, 0x18, 0x77, 0xa7,
-	0xbd, 0xd4, 0xd6, 0x57, 0x3f, 0x1d, 0x44, 0x8b, 0xda, 0xcf, 0x82, 0xcb, 0xef, 0xec, 0x8d, 0x69,
-	0x8e, 0x50, 0x68, 0x3a, 0x9f, 0xfd, 0xab, 0x6c, 0x8a, 0x4b, 0xe2, 0xdd, 0x86, 0x7c, 0x64, 0x8e,
-	0x50, 0x2e, 0xf4, 0xe8, 0xa6, 0x2b, 0x8f, 0xde, 0x92, 0x41, 0x77, 0xc0, 0xe6, 0x4a, 0x4a, 0xdc,
-	0xdc, 0x8e, 0xa1, 0x64, 0xb4, 0xb7, 0x27, 0x31, 0x8f, 0x38, 0xf2, 0x04, 0xd0, 0x68, 0x7b, 0x5b,
-	0x4f, 0x56, 0x72, 0xb1, 0xbf, 0x59, 0x27, 0xbd, 0x1e, 0xda, 0x7f, 0xe8, 0xfa, 0x37, 0x00, 0x00,
-	0xff, 0xff, 0x36, 0x67, 0x2e, 0xa0, 0x54, 0x02, 0x00, 0x00,
+var fileDescriptor_storage_761b0d99bd4e86bf = []byte{
+	// 267 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x7c, 0x92, 0xc1, 0x4a, 0xc3, 0x40,
+	0x10, 0x86, 0x49, 0x2b, 0x86, 0xfe, 0x6a, 0x6a, 0xc7, 0x82, 0x21, 0xf5, 0x50, 0x16, 0x0a, 0xf5,
+	0xd2, 0x83, 0x82, 0xa7, 0x9e, 0x44, 0x51, 0xf0, 0x22, 0xe9, 0x13, 0xa4, 0x3a, 0x88, 0xb4, 0xb8,
+	0x35, 0xbb, 0x15, 0xf2, 0x30, 0xbe, 0xab, 0x98, 0x4c, 0xb7, 0x9b, 0xb6, 0xe4, 0x36, 0xc9, 0xcc,
+	0xf7, 0x67, 0xe6, 0x23, 0x38, 0x33, 0x56, 0xe7, 0xd9, 0x07, 0x4f, 0x56, 0xb9, 0xb6, 0x9a, 0x42,
+	0x79, 0x54, 0x0a, 0xd1, 0x13, 0xdb, 0xfb, 0xa5, 0x9e, 0xa7, 0xfc, 0xbd, 0x66, 0x63, 0xe9, 0x1c,
+	0xed, 0x05, 0x17, 0x71, 0x30, 0x0c, 0xc6, 0x9d, 0xf4, 0xbf, 0x54, 0x23, 0x74, 0xdd, 0x8c, 0x59,
+	0xe9, 0x2f, 0xc3, 0x44, 0x38, 0x7a, 0xcf, 0x6c, 0x56, 0x4e, 0x9d, 0xa6, 0x65, 0xad, 0xee, 0x10,
+	0xbd, 0xae, 0x9b, 0xa3, 0x1c, 0xd7, 0xf2, 0xb8, 0x1e, 0xba, 0x8e, 0xab, 0xe2, 0xd5, 0x08, 0xbd,
+	0x07, 0x5e, 0xb2, 0xe5, 0xe6, 0xc5, 0xfa, 0x20, 0x7f, 0x4c, 0xe0, 0x3e, 0x48, 0xd6, 0x7d, 0xe1,
+	0xc2, 0x08, 0xad, 0xae, 0x71, 0x51, 0x7b, 0xbb, 0x3d, 0x64, 0xc1, 0x85, 0x89, 0x83, 0x61, 0x7b,
+	0xdc, 0x49, 0xcb, 0xfa, 0xe6, 0xb7, 0x85, 0x68, 0x56, 0xf9, 0x99, 0x71, 0xfe, 0xf3, 0xf9, 0xc6,
+	0x34, 0x45, 0x28, 0x34, 0x5d, 0x4e, 0x36, 0x2a, 0xeb, 0xe2, 0x92, 0x78, 0xbf, 0x21, 0x1f, 0x99,
+	0x22, 0x94, 0x0b, 0x3d, 0xba, 0xee, 0xca, 0xa3, 0x77, 0x64, 0xd0, 0x23, 0xb0, 0xbd, 0x92, 0x12,
+	0x37, 0xb7, 0x67, 0x28, 0x19, 0x1c, 0xec, 0x49, 0xcc, 0x33, 0x4e, 0x3c, 0x01, 0x34, 0xd8, 0xdd,
+	0xd6, 0x93, 0x95, 0x5c, 0x1d, 0x6e, 0x56, 0x49, 0xf3, 0xe3, 0xf2, 0x1f, 0xba, 0xfd, 0x0b, 0x00,
+	0x00, 0xff, 0xff, 0xf4, 0xc8, 0x88, 0x08, 0x54, 0x02, 0x00, 0x00,
 }

--- a/pkg/pb/storage/storage.proto
+++ b/pkg/pb/storage/storage.proto
@@ -16,36 +16,36 @@ syntax = "proto3";
 
 package storage;
 
-message GetFileRequest {
+message GetBlobRequest {
     string key = 1;
 }
 
-message GetFileResponse {
-    bytes file = 1;
+message GetBlobResponse {
+    bytes data = 1;
 }
 
-message PutFileRequest {
+message PutBlobRequest {
     string key = 1;
-    bytes file = 2;
+    bytes data = 2;
 }
 
-message PutFileResponse { }
+message PutBlobResponse { }
 
-message DeleteFileRequest {
+message DeleteBlobRequest {
     string key = 1;
 }
 
-message DeleteFileResponse { }
+message DeleteBlobResponse { }
 
-message GetFileKeysRequest { }
+message GetBlobKeysRequest { }
 
-message GetFileKeysResponse {
+message GetBlobKeysResponse {
   repeated string keys = 1;
 }
 
 service StorageService {
-    rpc GetFile (GetFileRequest) returns (GetFileResponse);
-    rpc PutFile (PutFileRequest) returns (PutFileResponse);
-    rpc DeleteFile (DeleteFileRequest) returns (DeleteFileResponse);
-    rpc GetFileKeys (GetFileKeysRequest) returns (GetFileKeysResponse);
+    rpc GetBlob (GetBlobRequest) returns (GetBlobResponse);
+    rpc PutBlob (PutBlobRequest) returns (PutBlobResponse);
+    rpc DeleteBlob (DeleteBlobRequest) returns (DeleteBlobResponse);
+    rpc GetBlobKeys (GetBlobKeysRequest) returns (GetBlobKeysResponse);
 }


### PR DESCRIPTION
Implement `fuse.MkDir` hook, additionally incorporate deletion of
directories. Also included are stored metadata regarding file/folder
permissions/last modified+creation time and safe generation of inodes.

```
$ mkdir -p a/b/c/d/e/f/g/h/i
$ echo "nested" > a/b/c/d/nested.txt
$ mkdir -p a/B/C/D
$ echo "also nested" > a/B/C/D/nested-two.txt
$ tree
.
└── a
    ├── B
    │   └── C
    │       └── D
    │           └── nested-two.txt
    └── b
        └── c
            └── d
                ├── e
                │   └── f
                │       └── g
                │           └── h
                │               └── i
                └── nested.txt

12 directories, 2 files

```

This supercedes #16. Additionally included are a bunch of proto changes to have better naming now that it's not simply a flat directory structure.
```diff
 service StorageService {
-    rpc GetFile (GetFileRequest) returns (GetFileResponse);
-    rpc PutFile (PutFileRequest) returns (PutFileResponse);
-    rpc DeleteFile (DeleteFileRequest) returns (DeleteFileResponse);
-    rpc GetFileKeys (GetFileKeysRequest) returns (GetFileKeysResponse);
+    rpc GetBlob (GetBlobRequest) returns (GetBlobResponse);
+    rpc PutBlob (PutBlobRequest) returns (PutBlobResponse);
+    rpc DeleteBlob (DeleteBlobRequest) returns (DeleteBlobResponse);
+    rpc GetBlobKeys (GetBlobKeysRequest) returns (GetBlobKeysResponse);
 }

 service MetadataService {
     rpc GetFile (GetFileRequest) returns (GetFileResponse);
     rpc PutFile (PutFileRequest) returns (PutFileResponse);
     rpc DeleteFile (DeleteFileRequest) returns (DeleteFileResponse);
+    rpc CreateDirectory (CreateDirectoryRequest) returns (CreateDirectoryResponse);
+    rpc DeleteDirectory (DeleteDirectoryRequest) returns (DeleteDirectoryResponse);
+    rpc GetDirectoryEntries (GetDirectoryEntriesRequest) returns (GetDirectoryEntriesResponse);
+
     rpc GetMetadata (GetMetadataRequest) returns (GetMetadataResponse);
     rpc SetMetadata (SetMetadataRequest) returns (SetMetadataResponse);
-    rpc GetDirectoryKeys (GetDirectoryKeysRequest) returns (GetDirectoryKeysResponse);
 }

 message GetFileRequest {
-    string key = 1;
+  string path = 1;
 }
```

As seen in `GetFileRequest`, any content is addressable only by fully qualified path now.