### PR TITLE
Implement Rename

### DIFF
--- a/cmd/fuse-server/fs.go
+++ b/cmd/fuse-server/fs.go
@@ -251,6 +251,27 @@ func (d *Dir) Remove(ctx context.Context, req *fuse.RemoveRequest) error {
 	return nil
 }
 
+func (d *Dir) Rename(
+	ctx context.Context,
+	req *fuse.RenameRequest,
+	newDir fs.Node,
+) error {
+	d.fserver.mu.Lock()
+	defer d.fserver.mu.Unlock()
+
+	dir := newDir.(*Dir)
+	rq := &mpb.RenameRequest{
+		OldPath: path.Join(d.path, req.OldName),
+		NewPath: path.Join(dir.path, req.NewName),
+	}
+	_, err := d.fserver.metadataServerClient.Rename(ctx, rq)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // File implements both fs.Node and fs.Handle.
 type File struct {
 	path    string

--- a/cmd/metadata-server/server_test.go
+++ b/cmd/metadata-server/server_test.go
@@ -52,16 +52,22 @@ func (t *testStorageServiceClient) GetBlob(
 	return &spb.GetBlobResponse{Data: serialized}, nil
 }
 
-func (y *testStorageServiceClient) PutBlob(
+func (t *testStorageServiceClient) PutBlob(
 	ctx context.Context, in *spb.PutBlobRequest, opts ...grpc.CallOption,
 ) (*spb.PutBlobResponse, error) {
 	return &spb.PutBlobResponse{}, nil
 }
 
-func (y *testStorageServiceClient) DeleteBlob(
+func (t *testStorageServiceClient) DeleteBlob(
 	ctx context.Context, in *spb.DeleteBlobRequest, opts ...grpc.CallOption,
 ) (*spb.DeleteBlobResponse, error) {
 	return &spb.DeleteBlobResponse{}, nil
+}
+
+func (t *testStorageServiceClient) RenameBlob(
+	ctx context.Context, in *spb.RenameBlobRequest, opts ...grpc.CallOption,
+) (*spb.RenameBlobResponse, error) {
+	return &spb.RenameBlobResponse{}, nil
 }
 
 func (y *testStorageServiceClient) GetBlobKeys(

--- a/cmd/storage-server/server.go
+++ b/cmd/storage-server/server.go
@@ -31,6 +31,7 @@ type Store interface {
 	Has(key string) bool
 	Erase(key string) error
 	Keys() []string
+	Rename(oldKey, newKey string) error
 }
 
 type storageServer struct {
@@ -133,6 +134,17 @@ func (s *storageServer) DeleteBlob(ctx context.Context, req *spb.DeleteBlobReque
 	}
 
 	return &spb.DeleteBlobResponse{}, nil
+}
+
+func (s *storageServer) RenameBlob(ctx context.Context, req *spb.RenameBlobRequest) (*spb.RenameBlobResponse, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if err := s.store.Rename(req.OldKey, req.NewKey); err != nil {
+		return nil, err
+	}
+
+	return &spb.RenameBlobResponse{}, nil
 }
 
 func (s *storageServer) GetBlobKeys(ctx context.Context, req *spb.GetBlobKeysRequest) (*spb.GetBlobKeysResponse, error) {

--- a/cmd/storage-server/server_test.go
+++ b/cmd/storage-server/server_test.go
@@ -52,6 +52,10 @@ func (t *testStore) Keys() []string {
 	return nil
 }
 
+func (t *testStore) Rename(_, _ string) error {
+	return nil
+}
+
 func TestGetBlob(t *testing.T) {
 	logger := log.Discarder()
 	ctx := context.Background()

--- a/pkg/diskv/basic_test.go
+++ b/pkg/diskv/basic_test.go
@@ -49,6 +49,87 @@ func TestWriteReadErase(t *testing.T) {
 	}
 }
 
+func TestWriteRename(t *testing.T) {
+	d := New(Options{
+		BasePath:     "test-data",
+		CacheSizeMax: 1024,
+	})
+	defer d.EraseAll()
+	k, nk, v := "a", "b", []byte{'c'}
+	if err := d.Write(k, v); err != nil {
+		t.Fatalf("write: %s", err)
+	}
+	if readVal, err := d.Read(k); err != nil {
+		t.Fatalf("read: %s", err)
+	} else if bytes.Compare(v, readVal) != 0 {
+		t.Fatalf("read: expected %s, got %s", v, readVal)
+	}
+	if err := d.Rename(k, nk); err != nil {
+		t.Fatalf("rename: %s", err)
+	}
+	if readVal, err := d.Read(nk); err != nil {
+		t.Fatalf("read: %s", err)
+	} else if bytes.Compare(v, readVal) != 0 {
+		t.Fatalf("read: expected %s, got %s", v, readVal)
+	}
+	if readVal, err := d.Read(k); err == nil {
+		t.Fatalf("read: expected missing key, got %s", readVal)
+	}
+	if err := d.Erase(nk); err != nil {
+		t.Fatalf("erase: %s", err)
+	}
+}
+
+func TestWriteRenameOverwrite(t *testing.T) {
+	d := New(Options{
+		BasePath:     "test-data",
+		CacheSizeMax: 1024,
+	})
+	defer d.EraseAll()
+
+	af, bf, cf := "a.txt", "b.txt", "c.txt"
+	bef, aft := []byte("bef"), []byte("aft")
+	if err := d.Write(af, bef); err != nil {
+		t.Fatalf("write: %s", err)
+	}
+	if readVal, err := d.Read(af); err != nil {
+		t.Fatalf("read: %s", err)
+	} else if bytes.Compare(bef, readVal) != 0 {
+		t.Fatalf("read: expected %s, got %s", bef, readVal)
+	}
+
+	if err := d.Rename(af, bf); err != nil {
+		t.Fatalf("rename: %s", err)
+	}
+	if readVal, err := d.Read(bf); err != nil {
+		t.Fatalf("read: %s", err)
+	} else if bytes.Compare(bef, readVal) != 0 {
+		t.Fatalf("read: expected %s, got %s", bef, readVal)
+	}
+
+	if err := d.Write(cf, aft); err != nil {
+		t.Fatalf("write: %s", err)
+	}
+	if readVal, err := d.Read(cf); err != nil {
+		t.Fatalf("read: %s", err)
+	} else if bytes.Compare(aft, readVal) != 0 {
+		t.Fatalf("read: expected %s, got %s", aft, readVal)
+	}
+
+	if err := d.Rename(cf, bf); err != nil {
+		t.Fatalf("rename: %s", err)
+	}
+	if readVal, err := d.Read(bf); err != nil {
+		t.Fatalf("read: %s", err)
+	} else if bytes.Compare(aft, readVal) != 0 {
+		t.Fatalf("read: expected %s, got %s", aft, readVal)
+	}
+
+	if err := d.Erase(bf); err != nil {
+		t.Fatalf("erase: %s", err)
+	}
+}
+
 func TestWRECache(t *testing.T) {
 	d := New(Options{
 		BasePath:     "test-data",

--- a/pkg/pb/metadata/metadata.pb.go
+++ b/pkg/pb/metadata/metadata.pb.go
@@ -40,7 +40,7 @@ func (m *Metadata) Reset()         { *m = Metadata{} }
 func (m *Metadata) String() string { return proto.CompactTextString(m) }
 func (*Metadata) ProtoMessage()    {}
 func (*Metadata) Descriptor() ([]byte, []int) {
-	return fileDescriptor_metadata_f1e41a50d647e56e, []int{0}
+	return fileDescriptor_metadata_8e6d7c0c9b907c72, []int{0}
 }
 func (m *Metadata) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Metadata.Unmarshal(m, b)
@@ -107,7 +107,7 @@ func (m *Metadata_UnixTimestamp) Reset()         { *m = Metadata_UnixTimestamp{}
 func (m *Metadata_UnixTimestamp) String() string { return proto.CompactTextString(m) }
 func (*Metadata_UnixTimestamp) ProtoMessage()    {}
 func (*Metadata_UnixTimestamp) Descriptor() ([]byte, []int) {
-	return fileDescriptor_metadata_f1e41a50d647e56e, []int{0, 0}
+	return fileDescriptor_metadata_8e6d7c0c9b907c72, []int{0, 0}
 }
 func (m *Metadata_UnixTimestamp) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Metadata_UnixTimestamp.Unmarshal(m, b)
@@ -152,7 +152,7 @@ func (m *GetFileRequest) Reset()         { *m = GetFileRequest{} }
 func (m *GetFileRequest) String() string { return proto.CompactTextString(m) }
 func (*GetFileRequest) ProtoMessage()    {}
 func (*GetFileRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_metadata_f1e41a50d647e56e, []int{1}
+	return fileDescriptor_metadata_8e6d7c0c9b907c72, []int{1}
 }
 func (m *GetFileRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_GetFileRequest.Unmarshal(m, b)
@@ -191,7 +191,7 @@ func (m *GetFileResponse) Reset()         { *m = GetFileResponse{} }
 func (m *GetFileResponse) String() string { return proto.CompactTextString(m) }
 func (*GetFileResponse) ProtoMessage()    {}
 func (*GetFileResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_metadata_f1e41a50d647e56e, []int{2}
+	return fileDescriptor_metadata_8e6d7c0c9b907c72, []int{2}
 }
 func (m *GetFileResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_GetFileResponse.Unmarshal(m, b)
@@ -236,7 +236,7 @@ func (m *GetFileStreamRequest) Reset()         { *m = GetFileStreamRequest{} }
 func (m *GetFileStreamRequest) String() string { return proto.CompactTextString(m) }
 func (*GetFileStreamRequest) ProtoMessage()    {}
 func (*GetFileStreamRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_metadata_f1e41a50d647e56e, []int{3}
+	return fileDescriptor_metadata_8e6d7c0c9b907c72, []int{3}
 }
 func (m *GetFileStreamRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_GetFileStreamRequest.Unmarshal(m, b)
@@ -276,7 +276,7 @@ func (m *GetFileStreamResponse) Reset()         { *m = GetFileStreamResponse{} }
 func (m *GetFileStreamResponse) String() string { return proto.CompactTextString(m) }
 func (*GetFileStreamResponse) ProtoMessage()    {}
 func (*GetFileStreamResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_metadata_f1e41a50d647e56e, []int{4}
+	return fileDescriptor_metadata_8e6d7c0c9b907c72, []int{4}
 }
 func (m *GetFileStreamResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_GetFileStreamResponse.Unmarshal(m, b)
@@ -323,7 +323,7 @@ func (m *PutFileRequest) Reset()         { *m = PutFileRequest{} }
 func (m *PutFileRequest) String() string { return proto.CompactTextString(m) }
 func (*PutFileRequest) ProtoMessage()    {}
 func (*PutFileRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_metadata_f1e41a50d647e56e, []int{5}
+	return fileDescriptor_metadata_8e6d7c0c9b907c72, []int{5}
 }
 func (m *PutFileRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_PutFileRequest.Unmarshal(m, b)
@@ -374,7 +374,7 @@ func (m *PutFileResponse) Reset()         { *m = PutFileResponse{} }
 func (m *PutFileResponse) String() string { return proto.CompactTextString(m) }
 func (*PutFileResponse) ProtoMessage()    {}
 func (*PutFileResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_metadata_f1e41a50d647e56e, []int{6}
+	return fileDescriptor_metadata_8e6d7c0c9b907c72, []int{6}
 }
 func (m *PutFileResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_PutFileResponse.Unmarshal(m, b)
@@ -408,7 +408,7 @@ func (m *PutFileStreamRequest) Reset()         { *m = PutFileStreamRequest{} }
 func (m *PutFileStreamRequest) String() string { return proto.CompactTextString(m) }
 func (*PutFileStreamRequest) ProtoMessage()    {}
 func (*PutFileStreamRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_metadata_f1e41a50d647e56e, []int{7}
+	return fileDescriptor_metadata_8e6d7c0c9b907c72, []int{7}
 }
 func (m *PutFileStreamRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_PutFileStreamRequest.Unmarshal(m, b)
@@ -459,7 +459,7 @@ func (m *PutFileStreamResponse) Reset()         { *m = PutFileStreamResponse{} }
 func (m *PutFileStreamResponse) String() string { return proto.CompactTextString(m) }
 func (*PutFileStreamResponse) ProtoMessage()    {}
 func (*PutFileStreamResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_metadata_f1e41a50d647e56e, []int{8}
+	return fileDescriptor_metadata_8e6d7c0c9b907c72, []int{8}
 }
 func (m *PutFileStreamResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_PutFileStreamResponse.Unmarshal(m, b)
@@ -490,7 +490,7 @@ func (m *DeleteFileRequest) Reset()         { *m = DeleteFileRequest{} }
 func (m *DeleteFileRequest) String() string { return proto.CompactTextString(m) }
 func (*DeleteFileRequest) ProtoMessage()    {}
 func (*DeleteFileRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_metadata_f1e41a50d647e56e, []int{9}
+	return fileDescriptor_metadata_8e6d7c0c9b907c72, []int{9}
 }
 func (m *DeleteFileRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_DeleteFileRequest.Unmarshal(m, b)
@@ -527,7 +527,7 @@ func (m *DeleteFileResponse) Reset()         { *m = DeleteFileResponse{} }
 func (m *DeleteFileResponse) String() string { return proto.CompactTextString(m) }
 func (*DeleteFileResponse) ProtoMessage()    {}
 func (*DeleteFileResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_metadata_f1e41a50d647e56e, []int{10}
+	return fileDescriptor_metadata_8e6d7c0c9b907c72, []int{10}
 }
 func (m *DeleteFileResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_DeleteFileResponse.Unmarshal(m, b)
@@ -558,7 +558,7 @@ func (m *GetDirectoryEntriesRequest) Reset()         { *m = GetDirectoryEntriesR
 func (m *GetDirectoryEntriesRequest) String() string { return proto.CompactTextString(m) }
 func (*GetDirectoryEntriesRequest) ProtoMessage()    {}
 func (*GetDirectoryEntriesRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_metadata_f1e41a50d647e56e, []int{11}
+	return fileDescriptor_metadata_8e6d7c0c9b907c72, []int{11}
 }
 func (m *GetDirectoryEntriesRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_GetDirectoryEntriesRequest.Unmarshal(m, b)
@@ -596,7 +596,7 @@ func (m *GetDirectoryEntriesResponse) Reset()         { *m = GetDirectoryEntries
 func (m *GetDirectoryEntriesResponse) String() string { return proto.CompactTextString(m) }
 func (*GetDirectoryEntriesResponse) ProtoMessage()    {}
 func (*GetDirectoryEntriesResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_metadata_f1e41a50d647e56e, []int{12}
+	return fileDescriptor_metadata_8e6d7c0c9b907c72, []int{12}
 }
 func (m *GetDirectoryEntriesResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_GetDirectoryEntriesResponse.Unmarshal(m, b)
@@ -639,7 +639,7 @@ func (m *GetDirectoryEntriesResponse_DirectoryEntry) String() string {
 }
 func (*GetDirectoryEntriesResponse_DirectoryEntry) ProtoMessage() {}
 func (*GetDirectoryEntriesResponse_DirectoryEntry) Descriptor() ([]byte, []int) {
-	return fileDescriptor_metadata_f1e41a50d647e56e, []int{12, 0}
+	return fileDescriptor_metadata_8e6d7c0c9b907c72, []int{12, 0}
 }
 func (m *GetDirectoryEntriesResponse_DirectoryEntry) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_GetDirectoryEntriesResponse_DirectoryEntry.Unmarshal(m, b)
@@ -685,7 +685,7 @@ func (m *CreateDirectoryRequest) Reset()         { *m = CreateDirectoryRequest{}
 func (m *CreateDirectoryRequest) String() string { return proto.CompactTextString(m) }
 func (*CreateDirectoryRequest) ProtoMessage()    {}
 func (*CreateDirectoryRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_metadata_f1e41a50d647e56e, []int{13}
+	return fileDescriptor_metadata_8e6d7c0c9b907c72, []int{13}
 }
 func (m *CreateDirectoryRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_CreateDirectoryRequest.Unmarshal(m, b)
@@ -729,7 +729,7 @@ func (m *CreateDirectoryResponse) Reset()         { *m = CreateDirectoryResponse
 func (m *CreateDirectoryResponse) String() string { return proto.CompactTextString(m) }
 func (*CreateDirectoryResponse) ProtoMessage()    {}
 func (*CreateDirectoryResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_metadata_f1e41a50d647e56e, []int{14}
+	return fileDescriptor_metadata_8e6d7c0c9b907c72, []int{14}
 }
 func (m *CreateDirectoryResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_CreateDirectoryResponse.Unmarshal(m, b)
@@ -760,7 +760,7 @@ func (m *DeleteDirectoryRequest) Reset()         { *m = DeleteDirectoryRequest{}
 func (m *DeleteDirectoryRequest) String() string { return proto.CompactTextString(m) }
 func (*DeleteDirectoryRequest) ProtoMessage()    {}
 func (*DeleteDirectoryRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_metadata_f1e41a50d647e56e, []int{15}
+	return fileDescriptor_metadata_8e6d7c0c9b907c72, []int{15}
 }
 func (m *DeleteDirectoryRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_DeleteDirectoryRequest.Unmarshal(m, b)
@@ -797,7 +797,7 @@ func (m *DeleteDirectoryResponse) Reset()         { *m = DeleteDirectoryResponse
 func (m *DeleteDirectoryResponse) String() string { return proto.CompactTextString(m) }
 func (*DeleteDirectoryResponse) ProtoMessage()    {}
 func (*DeleteDirectoryResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_metadata_f1e41a50d647e56e, []int{16}
+	return fileDescriptor_metadata_8e6d7c0c9b907c72, []int{16}
 }
 func (m *DeleteDirectoryResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_DeleteDirectoryResponse.Unmarshal(m, b)
@@ -828,7 +828,7 @@ func (m *GetMetadataRequest) Reset()         { *m = GetMetadataRequest{} }
 func (m *GetMetadataRequest) String() string { return proto.CompactTextString(m) }
 func (*GetMetadataRequest) ProtoMessage()    {}
 func (*GetMetadataRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_metadata_f1e41a50d647e56e, []int{17}
+	return fileDescriptor_metadata_8e6d7c0c9b907c72, []int{17}
 }
 func (m *GetMetadataRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_GetMetadataRequest.Unmarshal(m, b)
@@ -866,7 +866,7 @@ func (m *GetMetadataResponse) Reset()         { *m = GetMetadataResponse{} }
 func (m *GetMetadataResponse) String() string { return proto.CompactTextString(m) }
 func (*GetMetadataResponse) ProtoMessage()    {}
 func (*GetMetadataResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_metadata_f1e41a50d647e56e, []int{18}
+	return fileDescriptor_metadata_8e6d7c0c9b907c72, []int{18}
 }
 func (m *GetMetadataResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_GetMetadataResponse.Unmarshal(m, b)
@@ -905,7 +905,7 @@ func (m *SetMetadataRequest) Reset()         { *m = SetMetadataRequest{} }
 func (m *SetMetadataRequest) String() string { return proto.CompactTextString(m) }
 func (*SetMetadataRequest) ProtoMessage()    {}
 func (*SetMetadataRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_metadata_f1e41a50d647e56e, []int{19}
+	return fileDescriptor_metadata_8e6d7c0c9b907c72, []int{19}
 }
 func (m *SetMetadataRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SetMetadataRequest.Unmarshal(m, b)
@@ -949,7 +949,7 @@ func (m *SetMetadataResponse) Reset()         { *m = SetMetadataResponse{} }
 func (m *SetMetadataResponse) String() string { return proto.CompactTextString(m) }
 func (*SetMetadataResponse) ProtoMessage()    {}
 func (*SetMetadataResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_metadata_f1e41a50d647e56e, []int{20}
+	return fileDescriptor_metadata_8e6d7c0c9b907c72, []int{20}
 }
 func (m *SetMetadataResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SetMetadataResponse.Unmarshal(m, b)
@@ -968,6 +968,82 @@ func (m *SetMetadataResponse) XXX_DiscardUnknown() {
 }
 
 var xxx_messageInfo_SetMetadataResponse proto.InternalMessageInfo
+
+type RenameRequest struct {
+	OldPath              string   `protobuf:"bytes,1,opt,name=old_path,json=oldPath,proto3" json:"old_path,omitempty"`
+	NewPath              string   `protobuf:"bytes,2,opt,name=new_path,json=newPath,proto3" json:"new_path,omitempty"`
+	XXX_NoUnkeyedLiteral struct{} `json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
+	XXX_sizecache        int32    `json:"-"`
+}
+
+func (m *RenameRequest) Reset()         { *m = RenameRequest{} }
+func (m *RenameRequest) String() string { return proto.CompactTextString(m) }
+func (*RenameRequest) ProtoMessage()    {}
+func (*RenameRequest) Descriptor() ([]byte, []int) {
+	return fileDescriptor_metadata_8e6d7c0c9b907c72, []int{21}
+}
+func (m *RenameRequest) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_RenameRequest.Unmarshal(m, b)
+}
+func (m *RenameRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_RenameRequest.Marshal(b, m, deterministic)
+}
+func (dst *RenameRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_RenameRequest.Merge(dst, src)
+}
+func (m *RenameRequest) XXX_Size() int {
+	return xxx_messageInfo_RenameRequest.Size(m)
+}
+func (m *RenameRequest) XXX_DiscardUnknown() {
+	xxx_messageInfo_RenameRequest.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_RenameRequest proto.InternalMessageInfo
+
+func (m *RenameRequest) GetOldPath() string {
+	if m != nil {
+		return m.OldPath
+	}
+	return ""
+}
+
+func (m *RenameRequest) GetNewPath() string {
+	if m != nil {
+		return m.NewPath
+	}
+	return ""
+}
+
+type RenameResponse struct {
+	XXX_NoUnkeyedLiteral struct{} `json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
+	XXX_sizecache        int32    `json:"-"`
+}
+
+func (m *RenameResponse) Reset()         { *m = RenameResponse{} }
+func (m *RenameResponse) String() string { return proto.CompactTextString(m) }
+func (*RenameResponse) ProtoMessage()    {}
+func (*RenameResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_metadata_8e6d7c0c9b907c72, []int{22}
+}
+func (m *RenameResponse) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_RenameResponse.Unmarshal(m, b)
+}
+func (m *RenameResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_RenameResponse.Marshal(b, m, deterministic)
+}
+func (dst *RenameResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_RenameResponse.Merge(dst, src)
+}
+func (m *RenameResponse) XXX_Size() int {
+	return xxx_messageInfo_RenameResponse.Size(m)
+}
+func (m *RenameResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_RenameResponse.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_RenameResponse proto.InternalMessageInfo
 
 func init() {
 	proto.RegisterType((*Metadata)(nil), "metadata.Metadata")
@@ -993,6 +1069,8 @@ func init() {
 	proto.RegisterType((*GetMetadataResponse)(nil), "metadata.GetMetadataResponse")
 	proto.RegisterType((*SetMetadataRequest)(nil), "metadata.SetMetadataRequest")
 	proto.RegisterType((*SetMetadataResponse)(nil), "metadata.SetMetadataResponse")
+	proto.RegisterType((*RenameRequest)(nil), "metadata.RenameRequest")
+	proto.RegisterType((*RenameResponse)(nil), "metadata.RenameResponse")
 }
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -1015,6 +1093,7 @@ type MetadataServiceClient interface {
 	CreateDirectory(ctx context.Context, in *CreateDirectoryRequest, opts ...grpc.CallOption) (*CreateDirectoryResponse, error)
 	DeleteDirectory(ctx context.Context, in *DeleteDirectoryRequest, opts ...grpc.CallOption) (*DeleteDirectoryResponse, error)
 	GetDirectoryEntries(ctx context.Context, in *GetDirectoryEntriesRequest, opts ...grpc.CallOption) (*GetDirectoryEntriesResponse, error)
+	Rename(ctx context.Context, in *RenameRequest, opts ...grpc.CallOption) (*RenameResponse, error)
 	GetMetadata(ctx context.Context, in *GetMetadataRequest, opts ...grpc.CallOption) (*GetMetadataResponse, error)
 	SetMetadata(ctx context.Context, in *SetMetadataRequest, opts ...grpc.CallOption) (*SetMetadataResponse, error)
 }
@@ -1147,6 +1226,15 @@ func (c *metadataServiceClient) GetDirectoryEntries(ctx context.Context, in *Get
 	return out, nil
 }
 
+func (c *metadataServiceClient) Rename(ctx context.Context, in *RenameRequest, opts ...grpc.CallOption) (*RenameResponse, error) {
+	out := new(RenameResponse)
+	err := c.cc.Invoke(ctx, "/metadata.MetadataService/Rename", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 func (c *metadataServiceClient) GetMetadata(ctx context.Context, in *GetMetadataRequest, opts ...grpc.CallOption) (*GetMetadataResponse, error) {
 	out := new(GetMetadataResponse)
 	err := c.cc.Invoke(ctx, "/metadata.MetadataService/GetMetadata", in, out, opts...)
@@ -1175,6 +1263,7 @@ type MetadataServiceServer interface {
 	CreateDirectory(context.Context, *CreateDirectoryRequest) (*CreateDirectoryResponse, error)
 	DeleteDirectory(context.Context, *DeleteDirectoryRequest) (*DeleteDirectoryResponse, error)
 	GetDirectoryEntries(context.Context, *GetDirectoryEntriesRequest) (*GetDirectoryEntriesResponse, error)
+	Rename(context.Context, *RenameRequest) (*RenameResponse, error)
 	GetMetadata(context.Context, *GetMetadataRequest) (*GetMetadataResponse, error)
 	SetMetadata(context.Context, *SetMetadataRequest) (*SetMetadataResponse, error)
 }
@@ -1338,6 +1427,24 @@ func _MetadataService_GetDirectoryEntries_Handler(srv interface{}, ctx context.C
 	return interceptor(ctx, in, info, handler)
 }
 
+func _MetadataService_Rename_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(RenameRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(MetadataServiceServer).Rename(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/metadata.MetadataService/Rename",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(MetadataServiceServer).Rename(ctx, req.(*RenameRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 func _MetadataService_GetMetadata_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(GetMetadataRequest)
 	if err := dec(in); err != nil {
@@ -1403,6 +1510,10 @@ var _MetadataService_serviceDesc = grpc.ServiceDesc{
 			Handler:    _MetadataService_GetDirectoryEntries_Handler,
 		},
 		{
+			MethodName: "Rename",
+			Handler:    _MetadataService_Rename_Handler,
+		},
+		{
 			MethodName: "GetMetadata",
 			Handler:    _MetadataService_GetMetadata_Handler,
 		},
@@ -1426,51 +1537,55 @@ var _MetadataService_serviceDesc = grpc.ServiceDesc{
 	Metadata: "metadata.proto",
 }
 
-func init() { proto.RegisterFile("metadata.proto", fileDescriptor_metadata_f1e41a50d647e56e) }
+func init() { proto.RegisterFile("metadata.proto", fileDescriptor_metadata_8e6d7c0c9b907c72) }
 
-var fileDescriptor_metadata_f1e41a50d647e56e = []byte{
-	// 678 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x94, 0x56, 0x4d, 0x6f, 0xd3, 0x40,
-	0x10, 0x95, 0x93, 0xb6, 0x29, 0x93, 0x26, 0x51, 0xb7, 0x69, 0xeb, 0xba, 0x05, 0xdc, 0xa8, 0x08,
-	0x0b, 0xa1, 0xa8, 0x2a, 0x9c, 0x38, 0x70, 0xa1, 0x25, 0x12, 0xa8, 0x08, 0x39, 0x14, 0x71, 0x00,
-	0x55, 0x6e, 0x3c, 0x55, 0x57, 0xc4, 0x1f, 0x78, 0xb7, 0x88, 0xf2, 0xa3, 0xb8, 0x20, 0xf1, 0xfb,
-	0x90, 0xed, 0xb5, 0xbd, 0xfe, 0x88, 0xe3, 0xde, 0xbc, 0x3b, 0x33, 0x6f, 0xde, 0xcc, 0xce, 0x9b,
-	0x04, 0xfa, 0x0e, 0x72, 0xcb, 0xb6, 0xb8, 0x35, 0xf6, 0x03, 0x8f, 0x7b, 0x64, 0x3d, 0x39, 0x8f,
-	0xfe, 0xb6, 0x60, 0xfd, 0x5c, 0x1c, 0xc8, 0x2b, 0xe8, 0xcc, 0x02, 0xb4, 0x38, 0xda, 0xaa, 0xa2,
-	0x2b, 0x46, 0xf7, 0x44, 0x1f, 0xa7, 0x81, 0x89, 0xd3, 0xf8, 0xc2, 0xa5, 0xbf, 0x3e, 0x51, 0x07,
-	0x19, 0xb7, 0x1c, 0xdf, 0x4c, 0x02, 0xc8, 0x19, 0xf4, 0xe6, 0x16, 0xe3, 0x97, 0x8e, 0x67, 0xd3,
-	0x6b, 0x8a, 0xb6, 0xda, 0x6a, 0x88, 0xb0, 0x11, 0x86, 0x9d, 0x8b, 0x28, 0xa2, 0x43, 0xd7, 0xc7,
-	0xc0, 0xa1, 0x8c, 0x51, 0xcf, 0x65, 0x6a, 0x5b, 0x57, 0x8c, 0x9e, 0x29, 0x5f, 0x11, 0x02, 0x2b,
-	0x8c, 0xfe, 0x46, 0x75, 0x45, 0x57, 0x8c, 0xb6, 0x19, 0x7d, 0x93, 0x43, 0xd8, 0xa0, 0xec, 0xd2,
-	0xa6, 0x01, 0xce, 0xb8, 0x17, 0xdc, 0xa9, 0xab, 0xba, 0x62, 0xac, 0x9b, 0x5d, 0xca, 0x4e, 0x93,
-	0x2b, 0xed, 0x3d, 0xf4, 0x72, 0x79, 0x89, 0x0a, 0x1d, 0x86, 0x33, 0xcf, 0xb5, 0x59, 0x54, 0x6c,
-	0xdb, 0x4c, 0x8e, 0x21, 0x07, 0xd7, 0x72, 0xbd, 0xc4, 0xda, 0x8a, 0xac, 0xf2, 0xd5, 0xe8, 0x08,
-	0xfa, 0x13, 0xe4, 0x6f, 0xe9, 0x1c, 0x4d, 0xfc, 0x71, 0x8b, 0x8c, 0x87, 0xac, 0x7c, 0x8b, 0xdf,
-	0x44, 0x50, 0x0f, 0xcc, 0xe8, 0x7b, 0x74, 0x01, 0x83, 0xd4, 0x8b, 0xf9, 0x9e, 0xcb, 0x30, 0x74,
-	0xbb, 0xa6, 0x73, 0x8c, 0xdc, 0x36, 0xcc, 0xe8, 0x9b, 0x8c, 0x21, 0x7d, 0x0e, 0xd1, 0x34, 0x52,
-	0x6e, 0x9a, 0x99, 0x3d, 0xd9, 0x33, 0x18, 0x0a, 0xd8, 0x29, 0x0f, 0xd0, 0x72, 0xea, 0x28, 0x7c,
-	0x83, 0xed, 0x82, 0xaf, 0x20, 0x32, 0x84, 0xd5, 0xd9, 0xcd, 0xad, 0xfb, 0x5d, 0x30, 0x89, 0x0f,
-	0xf7, 0xa6, 0x72, 0x03, 0xfd, 0x8f, 0xb7, 0xcb, 0xfa, 0x90, 0x16, 0xdd, 0x5a, 0x50, 0x74, 0xbb,
-	0x41, 0xa6, 0x4d, 0x18, 0xa4, 0x99, 0xe2, 0x12, 0x46, 0x3e, 0x0c, 0xc5, 0xd5, 0xd2, 0x3e, 0x64,
-	0xe5, 0xb6, 0x16, 0x95, 0xdb, 0x84, 0xc4, 0x2e, 0x6c, 0x17, 0x32, 0x0a, 0x2a, 0x4f, 0x61, 0xf3,
-	0x14, 0xe7, 0xc8, 0x71, 0xd9, 0x48, 0x0c, 0x81, 0xc8, 0x8e, 0x22, 0xfc, 0x18, 0xb4, 0x09, 0xf2,
-	0x74, 0x56, 0xcf, 0x5c, 0x1e, 0x50, 0x64, 0x75, 0x38, 0xff, 0x14, 0xd8, 0xaf, 0x0c, 0x11, 0xcf,
-	0xfb, 0x01, 0x3a, 0x18, 0x5f, 0xa9, 0x8a, 0xde, 0x36, 0xba, 0x27, 0x2f, 0xb3, 0xc2, 0x6a, 0xe2,
-	0xc6, 0x39, 0xc3, 0x9d, 0x99, 0x80, 0x68, 0x13, 0xe8, 0xe7, 0x4d, 0x95, 0x5d, 0x2e, 0xca, 0xb0,
-	0x55, 0x92, 0xe1, 0xe8, 0x2b, 0xec, 0xbc, 0x89, 0x36, 0x46, 0x7a, 0x55, 0xf7, 0x6c, 0xf7, 0x9d,
-	0xc7, 0x3d, 0xd8, 0x2d, 0xa1, 0x8b, 0x1e, 0x3f, 0x87, 0x9d, 0xb8, 0xf3, 0x4d, 0x12, 0x87, 0x40,
-	0x25, 0x6f, 0x01, 0x64, 0x00, 0x99, 0x20, 0x4f, 0x93, 0xd7, 0x80, 0x9c, 0xc1, 0x56, 0xce, 0x53,
-	0xbc, 0x8d, 0x5c, 0x94, 0xd2, 0xa0, 0xa8, 0x2f, 0x40, 0xa6, 0x8d, 0x12, 0xde, 0xbb, 0x5d, 0xdb,
-	0xb0, 0x35, 0x2d, 0x13, 0x3c, 0xf9, 0xb3, 0x06, 0x83, 0xe4, 0x72, 0x8a, 0xc1, 0x4f, 0x3a, 0x43,
-	0xf2, 0x1a, 0x3a, 0x62, 0x91, 0x10, 0x35, 0x37, 0x4a, 0xd2, 0xc4, 0x6b, 0x7b, 0x15, 0x16, 0x51,
-	0xb4, 0x09, 0xbd, 0xdc, 0x22, 0x22, 0x8f, 0x4a, 0xbe, 0x39, 0x15, 0x6b, 0x8f, 0x17, 0xda, 0x63,
-	0xc4, 0x63, 0x25, 0xe4, 0x24, 0xe4, 0x28, 0x73, 0xca, 0x2f, 0x24, 0x99, 0x53, 0x61, 0x81, 0x84,
-	0x9c, 0x72, 0x72, 0x96, 0x39, 0x55, 0x6d, 0x16, 0x99, 0x53, 0xe5, 0x1e, 0x30, 0x14, 0x32, 0x01,
-	0xc8, 0x04, 0x4e, 0xf6, 0xb3, 0x80, 0xd2, 0x7e, 0xd0, 0x0e, 0xaa, 0x8d, 0x82, 0xdc, 0x67, 0x18,
-	0x14, 0x46, 0x99, 0x48, 0xbf, 0xa5, 0xd5, 0x1a, 0xd2, 0x0e, 0x6b, 0x3c, 0x32, 0xdc, 0xc2, 0x64,
-	0xcb, 0xb8, 0xd5, 0x12, 0x91, 0x71, 0x17, 0xc8, 0x82, 0x5c, 0x45, 0xc3, 0x5e, 0x5c, 0x2c, 0xe4,
-	0x68, 0xc9, 0xde, 0x89, 0xf1, 0x9f, 0x34, 0xda, 0x4e, 0xe4, 0x1d, 0x74, 0x25, 0x41, 0x91, 0x83,
-	0x5c, 0x54, 0x41, 0x20, 0xda, 0xc3, 0x05, 0xd6, 0x0c, 0x6b, 0x5a, 0x8d, 0x35, 0xad, 0xc5, 0xaa,
-	0x10, 0xcc, 0xd5, 0x5a, 0xf4, 0xaf, 0xea, 0xc5, 0xff, 0x00, 0x00, 0x00, 0xff, 0xff, 0xea, 0x84,
-	0x5f, 0xda, 0x67, 0x09, 0x00, 0x00,
+var fileDescriptor_metadata_8e6d7c0c9b907c72 = []byte{
+	// 741 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x94, 0x56, 0xdd, 0x6e, 0xd3, 0x4a,
+	0x10, 0x96, 0x93, 0xb6, 0xc9, 0x99, 0x34, 0xc9, 0xe9, 0x36, 0x6d, 0x1d, 0xb7, 0xe7, 0x9c, 0x34,
+	0xea, 0x11, 0x16, 0x42, 0x51, 0x55, 0xb8, 0x02, 0x89, 0x1b, 0x1a, 0x22, 0x81, 0x8a, 0x2a, 0x87,
+	0x22, 0x2e, 0x40, 0x95, 0x1b, 0x4f, 0xd5, 0x15, 0xb1, 0x1d, 0xbc, 0x5b, 0x4a, 0x79, 0x2d, 0x24,
+	0x5e, 0x8a, 0x97, 0x40, 0xb6, 0xd7, 0xf6, 0xfa, 0x27, 0x8e, 0x7b, 0xe7, 0xdd, 0x99, 0xf9, 0xe6,
+	0x9b, 0xd9, 0x99, 0x2f, 0x81, 0x8e, 0x8d, 0xdc, 0xb4, 0x4c, 0x6e, 0x8e, 0x16, 0x9e, 0xcb, 0x5d,
+	0xd2, 0x8c, 0xce, 0xc3, 0x9f, 0x35, 0x68, 0x9e, 0x89, 0x03, 0x79, 0x0e, 0x8d, 0x99, 0x87, 0x26,
+	0x47, 0x4b, 0x55, 0x06, 0x8a, 0xde, 0x3a, 0x19, 0x8c, 0xe2, 0xc0, 0xc8, 0x69, 0x74, 0xe1, 0xd0,
+	0xef, 0xef, 0xa9, 0x8d, 0x8c, 0x9b, 0xf6, 0xc2, 0x88, 0x02, 0xc8, 0x18, 0xda, 0x73, 0x93, 0xf1,
+	0x4b, 0xdb, 0xb5, 0xe8, 0x35, 0x45, 0x4b, 0xad, 0x55, 0x44, 0xd8, 0xf4, 0xc3, 0xce, 0x44, 0x14,
+	0x19, 0x40, 0x6b, 0x81, 0x9e, 0x4d, 0x19, 0xa3, 0xae, 0xc3, 0xd4, 0xfa, 0x40, 0xd1, 0xdb, 0x86,
+	0x7c, 0x45, 0x08, 0xac, 0x31, 0xfa, 0x03, 0xd5, 0xb5, 0x81, 0xa2, 0xd7, 0x8d, 0xe0, 0x9b, 0x1c,
+	0xc2, 0x26, 0x65, 0x97, 0x16, 0xf5, 0x70, 0xc6, 0x5d, 0xef, 0x5e, 0x5d, 0x1f, 0x28, 0x7a, 0xd3,
+	0x68, 0x51, 0x76, 0x1a, 0x5d, 0x69, 0x6f, 0xa1, 0x9d, 0xca, 0x4b, 0x54, 0x68, 0x30, 0x9c, 0xb9,
+	0x8e, 0xc5, 0x82, 0x62, 0xeb, 0x46, 0x74, 0xf4, 0x39, 0x38, 0xa6, 0xe3, 0x46, 0xd6, 0x5a, 0x60,
+	0x95, 0xaf, 0x86, 0x47, 0xd0, 0x99, 0x20, 0x7f, 0x4d, 0xe7, 0x68, 0xe0, 0xd7, 0x5b, 0x64, 0xdc,
+	0x67, 0xb5, 0x30, 0xf9, 0x4d, 0x00, 0xf5, 0x97, 0x11, 0x7c, 0x0f, 0x2f, 0xa0, 0x1b, 0x7b, 0xb1,
+	0x85, 0xeb, 0x30, 0xf4, 0xdd, 0xae, 0xe9, 0x1c, 0x03, 0xb7, 0x4d, 0x23, 0xf8, 0x26, 0x23, 0x88,
+	0x9f, 0x43, 0x34, 0x8d, 0xe4, 0x9b, 0x66, 0x24, 0x4f, 0xf6, 0x18, 0x7a, 0x02, 0x76, 0xca, 0x3d,
+	0x34, 0xed, 0x32, 0x0a, 0x9f, 0x61, 0x27, 0xe3, 0x2b, 0x88, 0xf4, 0x60, 0x7d, 0x76, 0x73, 0xeb,
+	0x7c, 0x11, 0x4c, 0xc2, 0xc3, 0x83, 0xa9, 0xdc, 0x40, 0xe7, 0xfc, 0x76, 0x55, 0x1f, 0xe2, 0xa2,
+	0x6b, 0x4b, 0x8a, 0xae, 0x57, 0xc8, 0xb4, 0x05, 0xdd, 0x38, 0x53, 0x58, 0xc2, 0x70, 0x01, 0x3d,
+	0x71, 0xb5, 0xb2, 0x0f, 0x49, 0xb9, 0xb5, 0x65, 0xe5, 0x56, 0x21, 0xb1, 0x07, 0x3b, 0x99, 0x8c,
+	0x82, 0xca, 0x23, 0xd8, 0x3a, 0xc5, 0x39, 0x72, 0x5c, 0x35, 0x12, 0x3d, 0x20, 0xb2, 0xa3, 0x08,
+	0x3f, 0x06, 0x6d, 0x82, 0x3c, 0x9e, 0xd5, 0xb1, 0xc3, 0x3d, 0x8a, 0xac, 0x0c, 0xe7, 0x97, 0x02,
+	0xfb, 0x85, 0x21, 0xe2, 0x79, 0xdf, 0x41, 0x03, 0xc3, 0x2b, 0x55, 0x19, 0xd4, 0xf5, 0xd6, 0xc9,
+	0xb3, 0xa4, 0xb0, 0x92, 0xb8, 0x51, 0xca, 0x70, 0x6f, 0x44, 0x20, 0xda, 0x04, 0x3a, 0x69, 0x53,
+	0x61, 0x97, 0xb3, 0x6b, 0x58, 0xcb, 0xad, 0xe1, 0xf0, 0x13, 0xec, 0xbe, 0x0a, 0x14, 0x23, 0xbe,
+	0x2a, 0x7b, 0xb6, 0x87, 0xce, 0x63, 0x1f, 0xf6, 0x72, 0xe8, 0xa2, 0xc7, 0x4f, 0x60, 0x37, 0xec,
+	0x7c, 0x95, 0xc4, 0x3e, 0x50, 0xce, 0x5b, 0x00, 0xe9, 0x40, 0x26, 0xc8, 0xe3, 0xe4, 0x25, 0x20,
+	0x63, 0xd8, 0x4e, 0x79, 0x8a, 0xb7, 0x91, 0x8b, 0x52, 0x2a, 0x14, 0xf5, 0x11, 0xc8, 0xb4, 0x52,
+	0xc2, 0x07, 0xb7, 0x6b, 0x07, 0xb6, 0xa7, 0x79, 0x82, 0xc3, 0x31, 0xb4, 0x0d, 0x74, 0x4c, 0x3b,
+	0x9e, 0xe4, 0x3e, 0x34, 0xdd, 0xb9, 0x75, 0x29, 0xe5, 0x6b, 0xb8, 0x73, 0xeb, 0xdc, 0x4f, 0xd9,
+	0x87, 0xa6, 0x83, 0x77, 0xa1, 0xa9, 0x16, 0x9a, 0x1c, 0xbc, 0xf3, 0x4d, 0xc3, 0xbf, 0xa1, 0x13,
+	0xc1, 0x84, 0xc0, 0x27, 0xbf, 0x37, 0xa0, 0x1b, 0x65, 0x9b, 0xa2, 0xf7, 0x8d, 0xce, 0x90, 0xbc,
+	0x84, 0x86, 0x50, 0x28, 0xa2, 0xa6, 0x66, 0x54, 0x5a, 0x25, 0xad, 0x5f, 0x60, 0x11, 0xdd, 0x34,
+	0xa0, 0x9d, 0x52, 0x38, 0xf2, 0x6f, 0xce, 0x37, 0x25, 0x0f, 0xda, 0x7f, 0x4b, 0xed, 0x21, 0xe2,
+	0xb1, 0xe2, 0x73, 0x12, 0x7b, 0x2e, 0x73, 0x4a, 0x2b, 0x9d, 0xcc, 0x29, 0xa3, 0x4c, 0x3e, 0xa7,
+	0x94, 0x4e, 0xc8, 0x9c, 0x8a, 0x24, 0x4b, 0xe6, 0x54, 0x28, 0x30, 0xba, 0x42, 0x26, 0x00, 0x89,
+	0x72, 0x90, 0xfd, 0x24, 0x20, 0x27, 0x3c, 0xda, 0x41, 0xb1, 0x51, 0x90, 0xfb, 0x00, 0xdd, 0xcc,
+	0x8e, 0x10, 0xe9, 0x47, 0xba, 0x78, 0x39, 0xb5, 0xc3, 0x12, 0x8f, 0x04, 0x37, 0xb3, 0x32, 0x32,
+	0x6e, 0xf1, 0xee, 0xc9, 0xb8, 0x4b, 0xf6, 0x8d, 0x5c, 0x05, 0x5b, 0x94, 0x55, 0x2c, 0x72, 0xb4,
+	0x42, 0xd0, 0x42, 0xfc, 0xff, 0x2b, 0xc9, 0x1e, 0x79, 0x01, 0x1b, 0xe1, 0xa8, 0x92, 0xbd, 0x24,
+	0x20, 0xb5, 0x03, 0x9a, 0x9a, 0x37, 0x88, 0xe0, 0x37, 0xd0, 0x92, 0xd6, 0x9c, 0x1c, 0xa4, 0x52,
+	0x66, 0xd6, 0x56, 0xfb, 0x67, 0x89, 0x35, 0xc1, 0x9a, 0x16, 0x63, 0x4d, 0x4b, 0xb1, 0x0a, 0xd6,
+	0xf8, 0x6a, 0x23, 0xf8, 0xaf, 0xf7, 0xf4, 0x4f, 0x00, 0x00, 0x00, 0xff, 0xff, 0x09, 0x23, 0xf9,
+	0xc6, 0xfd, 0x09, 0x00, 0x00,
 }

--- a/pkg/pb/metadata/metadata.proto
+++ b/pkg/pb/metadata/metadata.proto
@@ -113,7 +113,12 @@ message SetMetadataRequest {
 
 message SetMetadataResponse { }
 
-// TODO: Create RPC to copy folder recursively.
+message RenameRequest {
+  string old_path = 1;
+  string new_path = 2;
+}
+
+message RenameResponse { }
 
 service MetadataService { 
     rpc GetFile (GetFileRequest) returns (GetFileResponse);
@@ -124,6 +129,8 @@ service MetadataService {
     rpc CreateDirectory (CreateDirectoryRequest) returns (CreateDirectoryResponse);
     rpc DeleteDirectory (DeleteDirectoryRequest) returns (DeleteDirectoryResponse);
     rpc GetDirectoryEntries (GetDirectoryEntriesRequest) returns (GetDirectoryEntriesResponse);
+
+    rpc Rename (RenameRequest) returns (RenameResponse);
 
     rpc GetMetadata (GetMetadataRequest) returns (GetMetadataResponse);
     rpc SetMetadata (SetMetadataRequest) returns (SetMetadataResponse);

--- a/pkg/pb/storage/storage.pb.go
+++ b/pkg/pb/storage/storage.pb.go
@@ -34,7 +34,7 @@ func (m *GetBlobRequest) Reset()         { *m = GetBlobRequest{} }
 func (m *GetBlobRequest) String() string { return proto.CompactTextString(m) }
 func (*GetBlobRequest) ProtoMessage()    {}
 func (*GetBlobRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_storage_d44917d2bed057f8, []int{0}
+	return fileDescriptor_storage_93615289172d4604, []int{0}
 }
 func (m *GetBlobRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_GetBlobRequest.Unmarshal(m, b)
@@ -72,7 +72,7 @@ func (m *GetBlobResponse) Reset()         { *m = GetBlobResponse{} }
 func (m *GetBlobResponse) String() string { return proto.CompactTextString(m) }
 func (*GetBlobResponse) ProtoMessage()    {}
 func (*GetBlobResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_storage_d44917d2bed057f8, []int{1}
+	return fileDescriptor_storage_93615289172d4604, []int{1}
 }
 func (m *GetBlobResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_GetBlobResponse.Unmarshal(m, b)
@@ -110,7 +110,7 @@ func (m *GetBlobStreamRequest) Reset()         { *m = GetBlobStreamRequest{} }
 func (m *GetBlobStreamRequest) String() string { return proto.CompactTextString(m) }
 func (*GetBlobStreamRequest) ProtoMessage()    {}
 func (*GetBlobStreamRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_storage_d44917d2bed057f8, []int{2}
+	return fileDescriptor_storage_93615289172d4604, []int{2}
 }
 func (m *GetBlobStreamRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_GetBlobStreamRequest.Unmarshal(m, b)
@@ -148,7 +148,7 @@ func (m *GetBlobStreamResponse) Reset()         { *m = GetBlobStreamResponse{} }
 func (m *GetBlobStreamResponse) String() string { return proto.CompactTextString(m) }
 func (*GetBlobStreamResponse) ProtoMessage()    {}
 func (*GetBlobStreamResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_storage_d44917d2bed057f8, []int{3}
+	return fileDescriptor_storage_93615289172d4604, []int{3}
 }
 func (m *GetBlobStreamResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_GetBlobStreamResponse.Unmarshal(m, b)
@@ -187,7 +187,7 @@ func (m *PutBlobRequest) Reset()         { *m = PutBlobRequest{} }
 func (m *PutBlobRequest) String() string { return proto.CompactTextString(m) }
 func (*PutBlobRequest) ProtoMessage()    {}
 func (*PutBlobRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_storage_d44917d2bed057f8, []int{4}
+	return fileDescriptor_storage_93615289172d4604, []int{4}
 }
 func (m *PutBlobRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_PutBlobRequest.Unmarshal(m, b)
@@ -231,7 +231,7 @@ func (m *PutBlobResponse) Reset()         { *m = PutBlobResponse{} }
 func (m *PutBlobResponse) String() string { return proto.CompactTextString(m) }
 func (*PutBlobResponse) ProtoMessage()    {}
 func (*PutBlobResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_storage_d44917d2bed057f8, []int{5}
+	return fileDescriptor_storage_93615289172d4604, []int{5}
 }
 func (m *PutBlobResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_PutBlobResponse.Unmarshal(m, b)
@@ -263,7 +263,7 @@ func (m *PutBlobStreamRequest) Reset()         { *m = PutBlobStreamRequest{} }
 func (m *PutBlobStreamRequest) String() string { return proto.CompactTextString(m) }
 func (*PutBlobStreamRequest) ProtoMessage()    {}
 func (*PutBlobStreamRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_storage_d44917d2bed057f8, []int{6}
+	return fileDescriptor_storage_93615289172d4604, []int{6}
 }
 func (m *PutBlobStreamRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_PutBlobStreamRequest.Unmarshal(m, b)
@@ -307,7 +307,7 @@ func (m *PutBlobStreamResponse) Reset()         { *m = PutBlobStreamResponse{} }
 func (m *PutBlobStreamResponse) String() string { return proto.CompactTextString(m) }
 func (*PutBlobStreamResponse) ProtoMessage()    {}
 func (*PutBlobStreamResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_storage_d44917d2bed057f8, []int{7}
+	return fileDescriptor_storage_93615289172d4604, []int{7}
 }
 func (m *PutBlobStreamResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_PutBlobStreamResponse.Unmarshal(m, b)
@@ -338,7 +338,7 @@ func (m *DeleteBlobRequest) Reset()         { *m = DeleteBlobRequest{} }
 func (m *DeleteBlobRequest) String() string { return proto.CompactTextString(m) }
 func (*DeleteBlobRequest) ProtoMessage()    {}
 func (*DeleteBlobRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_storage_d44917d2bed057f8, []int{8}
+	return fileDescriptor_storage_93615289172d4604, []int{8}
 }
 func (m *DeleteBlobRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_DeleteBlobRequest.Unmarshal(m, b)
@@ -375,7 +375,7 @@ func (m *DeleteBlobResponse) Reset()         { *m = DeleteBlobResponse{} }
 func (m *DeleteBlobResponse) String() string { return proto.CompactTextString(m) }
 func (*DeleteBlobResponse) ProtoMessage()    {}
 func (*DeleteBlobResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_storage_d44917d2bed057f8, []int{9}
+	return fileDescriptor_storage_93615289172d4604, []int{9}
 }
 func (m *DeleteBlobResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_DeleteBlobResponse.Unmarshal(m, b)
@@ -405,7 +405,7 @@ func (m *GetBlobKeysRequest) Reset()         { *m = GetBlobKeysRequest{} }
 func (m *GetBlobKeysRequest) String() string { return proto.CompactTextString(m) }
 func (*GetBlobKeysRequest) ProtoMessage()    {}
 func (*GetBlobKeysRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_storage_d44917d2bed057f8, []int{10}
+	return fileDescriptor_storage_93615289172d4604, []int{10}
 }
 func (m *GetBlobKeysRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_GetBlobKeysRequest.Unmarshal(m, b)
@@ -436,7 +436,7 @@ func (m *GetBlobKeysResponse) Reset()         { *m = GetBlobKeysResponse{} }
 func (m *GetBlobKeysResponse) String() string { return proto.CompactTextString(m) }
 func (*GetBlobKeysResponse) ProtoMessage()    {}
 func (*GetBlobKeysResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_storage_d44917d2bed057f8, []int{11}
+	return fileDescriptor_storage_93615289172d4604, []int{11}
 }
 func (m *GetBlobKeysResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_GetBlobKeysResponse.Unmarshal(m, b)
@@ -463,6 +463,82 @@ func (m *GetBlobKeysResponse) GetKeys() []string {
 	return nil
 }
 
+type RenameBlobRequest struct {
+	OldKey               string   `protobuf:"bytes,1,opt,name=old_key,json=oldKey,proto3" json:"old_key,omitempty"`
+	NewKey               string   `protobuf:"bytes,2,opt,name=new_key,json=newKey,proto3" json:"new_key,omitempty"`
+	XXX_NoUnkeyedLiteral struct{} `json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
+	XXX_sizecache        int32    `json:"-"`
+}
+
+func (m *RenameBlobRequest) Reset()         { *m = RenameBlobRequest{} }
+func (m *RenameBlobRequest) String() string { return proto.CompactTextString(m) }
+func (*RenameBlobRequest) ProtoMessage()    {}
+func (*RenameBlobRequest) Descriptor() ([]byte, []int) {
+	return fileDescriptor_storage_93615289172d4604, []int{12}
+}
+func (m *RenameBlobRequest) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_RenameBlobRequest.Unmarshal(m, b)
+}
+func (m *RenameBlobRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_RenameBlobRequest.Marshal(b, m, deterministic)
+}
+func (dst *RenameBlobRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_RenameBlobRequest.Merge(dst, src)
+}
+func (m *RenameBlobRequest) XXX_Size() int {
+	return xxx_messageInfo_RenameBlobRequest.Size(m)
+}
+func (m *RenameBlobRequest) XXX_DiscardUnknown() {
+	xxx_messageInfo_RenameBlobRequest.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_RenameBlobRequest proto.InternalMessageInfo
+
+func (m *RenameBlobRequest) GetOldKey() string {
+	if m != nil {
+		return m.OldKey
+	}
+	return ""
+}
+
+func (m *RenameBlobRequest) GetNewKey() string {
+	if m != nil {
+		return m.NewKey
+	}
+	return ""
+}
+
+type RenameBlobResponse struct {
+	XXX_NoUnkeyedLiteral struct{} `json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
+	XXX_sizecache        int32    `json:"-"`
+}
+
+func (m *RenameBlobResponse) Reset()         { *m = RenameBlobResponse{} }
+func (m *RenameBlobResponse) String() string { return proto.CompactTextString(m) }
+func (*RenameBlobResponse) ProtoMessage()    {}
+func (*RenameBlobResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_storage_93615289172d4604, []int{13}
+}
+func (m *RenameBlobResponse) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_RenameBlobResponse.Unmarshal(m, b)
+}
+func (m *RenameBlobResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_RenameBlobResponse.Marshal(b, m, deterministic)
+}
+func (dst *RenameBlobResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_RenameBlobResponse.Merge(dst, src)
+}
+func (m *RenameBlobResponse) XXX_Size() int {
+	return xxx_messageInfo_RenameBlobResponse.Size(m)
+}
+func (m *RenameBlobResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_RenameBlobResponse.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_RenameBlobResponse proto.InternalMessageInfo
+
 func init() {
 	proto.RegisterType((*GetBlobRequest)(nil), "storage.GetBlobRequest")
 	proto.RegisterType((*GetBlobResponse)(nil), "storage.GetBlobResponse")
@@ -476,6 +552,8 @@ func init() {
 	proto.RegisterType((*DeleteBlobResponse)(nil), "storage.DeleteBlobResponse")
 	proto.RegisterType((*GetBlobKeysRequest)(nil), "storage.GetBlobKeysRequest")
 	proto.RegisterType((*GetBlobKeysResponse)(nil), "storage.GetBlobKeysResponse")
+	proto.RegisterType((*RenameBlobRequest)(nil), "storage.RenameBlobRequest")
+	proto.RegisterType((*RenameBlobResponse)(nil), "storage.RenameBlobResponse")
 }
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -494,6 +572,7 @@ type StorageServiceClient interface {
 	GetBlobStream(ctx context.Context, in *GetBlobStreamRequest, opts ...grpc.CallOption) (StorageService_GetBlobStreamClient, error)
 	PutBlob(ctx context.Context, in *PutBlobRequest, opts ...grpc.CallOption) (*PutBlobResponse, error)
 	PutBlobStream(ctx context.Context, opts ...grpc.CallOption) (StorageService_PutBlobStreamClient, error)
+	RenameBlob(ctx context.Context, in *RenameBlobRequest, opts ...grpc.CallOption) (*RenameBlobResponse, error)
 	DeleteBlob(ctx context.Context, in *DeleteBlobRequest, opts ...grpc.CallOption) (*DeleteBlobResponse, error)
 	GetBlobKeys(ctx context.Context, in *GetBlobKeysRequest, opts ...grpc.CallOption) (*GetBlobKeysResponse, error)
 }
@@ -590,6 +669,15 @@ func (x *storageServicePutBlobStreamClient) CloseAndRecv() (*PutBlobStreamRespon
 	return m, nil
 }
 
+func (c *storageServiceClient) RenameBlob(ctx context.Context, in *RenameBlobRequest, opts ...grpc.CallOption) (*RenameBlobResponse, error) {
+	out := new(RenameBlobResponse)
+	err := c.cc.Invoke(ctx, "/storage.StorageService/RenameBlob", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 func (c *storageServiceClient) DeleteBlob(ctx context.Context, in *DeleteBlobRequest, opts ...grpc.CallOption) (*DeleteBlobResponse, error) {
 	out := new(DeleteBlobResponse)
 	err := c.cc.Invoke(ctx, "/storage.StorageService/DeleteBlob", in, out, opts...)
@@ -614,6 +702,7 @@ type StorageServiceServer interface {
 	GetBlobStream(*GetBlobStreamRequest, StorageService_GetBlobStreamServer) error
 	PutBlob(context.Context, *PutBlobRequest) (*PutBlobResponse, error)
 	PutBlobStream(StorageService_PutBlobStreamServer) error
+	RenameBlob(context.Context, *RenameBlobRequest) (*RenameBlobResponse, error)
 	DeleteBlob(context.Context, *DeleteBlobRequest) (*DeleteBlobResponse, error)
 	GetBlobKeys(context.Context, *GetBlobKeysRequest) (*GetBlobKeysResponse, error)
 }
@@ -705,6 +794,24 @@ func (x *storageServicePutBlobStreamServer) Recv() (*PutBlobStreamRequest, error
 	return m, nil
 }
 
+func _StorageService_RenameBlob_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(RenameBlobRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(StorageServiceServer).RenameBlob(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/storage.StorageService/RenameBlob",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(StorageServiceServer).RenameBlob(ctx, req.(*RenameBlobRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 func _StorageService_DeleteBlob_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(DeleteBlobRequest)
 	if err := dec(in); err != nil {
@@ -754,6 +861,10 @@ var _StorageService_serviceDesc = grpc.ServiceDesc{
 			Handler:    _StorageService_PutBlob_Handler,
 		},
 		{
+			MethodName: "RenameBlob",
+			Handler:    _StorageService_RenameBlob_Handler,
+		},
+		{
 			MethodName: "DeleteBlob",
 			Handler:    _StorageService_DeleteBlob_Handler,
 		},
@@ -777,30 +888,34 @@ var _StorageService_serviceDesc = grpc.ServiceDesc{
 	Metadata: "storage.proto",
 }
 
-func init() { proto.RegisterFile("storage.proto", fileDescriptor_storage_d44917d2bed057f8) }
+func init() { proto.RegisterFile("storage.proto", fileDescriptor_storage_93615289172d4604) }
 
-var fileDescriptor_storage_d44917d2bed057f8 = []byte{
-	// 348 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x84, 0x93, 0xd1, 0x4e, 0xf2, 0x40,
-	0x10, 0x85, 0x53, 0xf8, 0x7f, 0x09, 0xa3, 0x80, 0x8c, 0x25, 0x90, 0xa2, 0x86, 0x6c, 0x42, 0x52,
-	0x2f, 0x24, 0x46, 0x13, 0xaf, 0x8c, 0x17, 0x46, 0xa3, 0x89, 0x37, 0xa4, 0x3c, 0x41, 0xc1, 0x89,
-	0x1a, 0x90, 0x62, 0x77, 0x31, 0xe9, 0xe3, 0xf9, 0x66, 0xa6, 0xed, 0xd8, 0xee, 0x96, 0x82, 0x77,
-	0xdb, 0x9d, 0x33, 0x67, 0xbf, 0x9c, 0x93, 0x42, 0x43, 0xaa, 0x20, 0xf4, 0x5f, 0x69, 0xb4, 0x0a,
-	0x03, 0x15, 0x60, 0x8d, 0x3f, 0x85, 0x80, 0xe6, 0x23, 0xa9, 0xbb, 0x45, 0x30, 0xf5, 0xe8, 0x73,
-	0x4d, 0x52, 0xe1, 0x21, 0x54, 0xe7, 0x14, 0xf5, 0xac, 0x81, 0xe5, 0xd6, 0xbd, 0xf8, 0x28, 0x86,
-	0xd0, 0xca, 0x34, 0x72, 0x15, 0x2c, 0x25, 0x21, 0xc2, 0xbf, 0x17, 0x5f, 0xf9, 0x89, 0xea, 0xc0,
-	0x4b, 0xce, 0xc2, 0x05, 0x9b, 0x65, 0x13, 0x15, 0x92, 0xff, 0xb1, 0xdd, 0xf0, 0x1c, 0x3a, 0x05,
-	0x25, 0xdb, 0xda, 0xf0, 0x7f, 0xf6, 0xb6, 0x5e, 0xce, 0xd9, 0x37, 0xfd, 0x10, 0xd7, 0xd0, 0x1c,
-	0xaf, 0x77, 0x33, 0x66, 0x40, 0x15, 0x0d, 0xa8, 0x0d, 0xad, 0x6c, 0x2f, 0x7d, 0x40, 0xdc, 0x82,
-	0xcd, 0x57, 0x7f, 0x30, 0xe6, 0x28, 0x15, 0x1d, 0xa5, 0x0b, 0x9d, 0xc2, 0x3e, 0x1b, 0x0f, 0xa1,
-	0x7d, 0x4f, 0x0b, 0x52, 0xb4, 0x3b, 0x4a, 0x1b, 0x50, 0x97, 0xf1, 0xb2, 0x0d, 0xc8, 0x79, 0x3c,
-	0x53, 0x24, 0x79, 0x5b, 0x9c, 0xc1, 0x91, 0x71, 0x9b, 0x47, 0x3f, 0xa7, 0x48, 0xf6, 0xac, 0x41,
-	0xd5, 0xad, 0x7b, 0xc9, 0xf9, 0xf2, 0xbb, 0x0a, 0xcd, 0x49, 0xda, 0xe8, 0x84, 0xc2, 0xaf, 0xf7,
-	0x19, 0xe1, 0x0d, 0xd4, 0x78, 0x1b, 0xbb, 0xa3, 0xdf, 0xf2, 0xcd, 0xaa, 0x9d, 0xde, 0xe6, 0x80,
-	0x1f, 0x19, 0x43, 0xc3, 0x68, 0x08, 0x4f, 0x8a, 0x52, 0x23, 0x3f, 0xe7, 0x74, 0xdb, 0x38, 0xf5,
-	0xbb, 0xb0, 0x62, 0x1e, 0x4e, 0x4e, 0xe3, 0x31, 0x6b, 0xd5, 0x78, 0x0a, 0xbd, 0xc5, 0x3c, 0x46,
-	0xee, 0x1a, 0x4f, 0x59, 0x9f, 0x1a, 0x4f, 0x69, 0x5d, 0xae, 0x85, 0x0f, 0x00, 0x79, 0x13, 0xe8,
-	0x64, 0xfa, 0x8d, 0x16, 0x9d, 0x7e, 0xe9, 0x8c, 0xc1, 0x9e, 0x60, 0x5f, 0x2b, 0x09, 0xfb, 0xc5,
-	0x1c, 0xb4, 0x42, 0x9d, 0xe3, 0xf2, 0x61, 0xea, 0x34, 0xdd, 0x4b, 0xfe, 0xcc, 0xab, 0x9f, 0x00,
-	0x00, 0x00, 0xff, 0xff, 0xf6, 0x89, 0x9d, 0x12, 0xaa, 0x03, 0x00, 0x00,
+var fileDescriptor_storage_93615289172d4604 = []byte{
+	// 402 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x84, 0x94, 0xc1, 0x4e, 0xc2, 0x40,
+	0x10, 0x86, 0x53, 0x40, 0x08, 0xa3, 0x80, 0xac, 0x25, 0x90, 0xa2, 0x86, 0x6c, 0x42, 0x52, 0x0f,
+	0x12, 0xa3, 0x89, 0x27, 0xe3, 0xc1, 0x48, 0x34, 0xe1, 0x42, 0xca, 0x03, 0x98, 0x02, 0x13, 0x35,
+	0x94, 0x16, 0xdb, 0x45, 0xd2, 0x37, 0xf0, 0xb1, 0x4d, 0xbb, 0x6b, 0xbb, 0xdb, 0x16, 0xbc, 0x6d,
+	0x77, 0xfe, 0xf9, 0xf7, 0x63, 0xe6, 0x0f, 0xd0, 0x08, 0x98, 0xe7, 0xdb, 0xef, 0x38, 0xda, 0xf8,
+	0x1e, 0xf3, 0x48, 0x4d, 0x7c, 0x52, 0x0a, 0xcd, 0x17, 0x64, 0x4f, 0x8e, 0x37, 0xb7, 0xf0, 0x6b,
+	0x8b, 0x01, 0x23, 0xa7, 0x50, 0x5e, 0x61, 0xd8, 0xd3, 0x06, 0x9a, 0x59, 0xb7, 0xa2, 0x23, 0x1d,
+	0x42, 0x2b, 0xd1, 0x04, 0x1b, 0xcf, 0x0d, 0x90, 0x10, 0xa8, 0x2c, 0x6d, 0x66, 0xc7, 0xaa, 0x13,
+	0x2b, 0x3e, 0x53, 0x13, 0x74, 0x21, 0x9b, 0x31, 0x1f, 0xed, 0xf5, 0x7e, 0xc3, 0x6b, 0xe8, 0x64,
+	0x94, 0xc2, 0x56, 0x87, 0xa3, 0xc5, 0xc7, 0xd6, 0x5d, 0x09, 0x5f, 0xfe, 0x41, 0xef, 0xa1, 0x39,
+	0xdd, 0x1e, 0x66, 0x4c, 0x80, 0x4a, 0x12, 0x50, 0x1b, 0x5a, 0x49, 0x1f, 0x7f, 0x80, 0x3e, 0x82,
+	0x2e, 0xae, 0xfe, 0x61, 0x4c, 0x51, 0x4a, 0x32, 0x4a, 0x17, 0x3a, 0x99, 0x7e, 0x61, 0x3c, 0x84,
+	0xf6, 0x33, 0x3a, 0xc8, 0xf0, 0xf0, 0x28, 0x75, 0x20, 0xb2, 0x4c, 0x34, 0xeb, 0x40, 0xc4, 0x3c,
+	0x26, 0x18, 0x06, 0xa2, 0x9b, 0x5e, 0xc1, 0x99, 0x72, 0x9b, 0x8e, 0x7e, 0x85, 0x61, 0xd0, 0xd3,
+	0x06, 0x65, 0xb3, 0x6e, 0xc5, 0x67, 0x3a, 0x86, 0xb6, 0x85, 0xae, 0xbd, 0x56, 0x5e, 0xef, 0x42,
+	0xcd, 0x73, 0x96, 0x6f, 0x29, 0x41, 0xd5, 0x73, 0x96, 0x13, 0x0c, 0xa3, 0x82, 0x8b, 0xbb, 0xb8,
+	0x50, 0xe2, 0x05, 0x17, 0x77, 0x13, 0x4e, 0x27, 0xdb, 0xf0, 0x07, 0x6f, 0x7f, 0x2a, 0xd0, 0x9c,
+	0xf1, 0xb8, 0xcc, 0xd0, 0xff, 0xfe, 0x5c, 0x20, 0x79, 0x80, 0x9a, 0x40, 0x23, 0xdd, 0xd1, 0x5f,
+	0xb2, 0xd4, 0x1c, 0x19, 0xbd, 0x7c, 0x41, 0xfc, 0x82, 0x29, 0x34, 0x94, 0xf5, 0x93, 0x8b, 0xac,
+	0x54, 0x59, 0x8e, 0x71, 0xb9, 0xaf, 0xcc, 0xfd, 0x6e, 0xb4, 0x88, 0x47, 0xac, 0x45, 0xe2, 0x51,
+	0x33, 0x23, 0xf1, 0x64, 0x42, 0x11, 0xf1, 0x28, 0x4b, 0x95, 0x78, 0x8a, 0xc2, 0x22, 0xf1, 0x14,
+	0x66, 0xc1, 0xd4, 0xc8, 0x18, 0x20, 0x1d, 0x24, 0x31, 0x12, 0x7d, 0x6e, 0x49, 0x46, 0xbf, 0xb0,
+	0x26, 0xc0, 0xc6, 0x00, 0x69, 0x5a, 0x24, 0x9b, 0x5c, 0xd2, 0x24, 0x9b, 0x7c, 0xbc, 0xc8, 0x2b,
+	0x1c, 0x4b, 0x41, 0x22, 0xfd, 0xec, 0x38, 0xa5, 0xd0, 0x19, 0xe7, 0xc5, 0x45, 0xee, 0x34, 0xaf,
+	0xc6, 0xff, 0x1e, 0x77, 0xbf, 0x01, 0x00, 0x00, 0xff, 0xff, 0x2d, 0x3d, 0x76, 0x1d, 0x4e, 0x04,
+	0x00, 0x00,
 }

--- a/pkg/pb/storage/storage.proto
+++ b/pkg/pb/storage/storage.proto
@@ -58,11 +58,19 @@ message GetBlobKeysResponse {
   repeated string keys = 1;
 }
 
+message RenameBlobRequest {
+  string old_key = 1;
+  string new_key = 2;
+}
+
+message RenameBlobResponse { }
+
 service StorageService {
     rpc GetBlob (GetBlobRequest) returns (GetBlobResponse);
     rpc GetBlobStream (GetBlobStreamRequest) returns (stream GetBlobStreamResponse);
     rpc PutBlob (PutBlobRequest) returns (PutBlobResponse);
     rpc PutBlobStream (stream PutBlobStreamRequest) returns (PutBlobStreamResponse);
+    rpc RenameBlob (RenameBlobRequest) returns (RenameBlobResponse);
     rpc DeleteBlob (DeleteBlobRequest) returns (DeleteBlobResponse);
     rpc GetBlobKeys (GetBlobKeysRequest) returns (GetBlobKeysResponse);
 }


### PR DESCRIPTION
Possible rename/mv scenarios are handled as follows:

    OldPath      NewPathExists       NewPath     Result
    -------------------------------------------------------
    File         No                  N/A         Rename
    File         Yes                 File        Overwrite
    File         Yes                 Dir         Error!
    Dir          No                  N/A         Rename
    Dir          Yes                 File        Error!
    Dir          Yes                 Dir         Overwrite if empty, else Error!

For the last case, say we have the following tree structure, a and a'
are the same name but are distinguished to be able to talk about them.

    ├── a
    └── b
        └── a'
           [...]

If we try 'mv a b', it should fail if a' is non-empty. If a' is empty, we
should override to get the following:

    └── b
        └── a
